### PR TITLE
feat(web): add COE premium comparison to make pages

### DIFF
--- a/apps/web/src/app/(dashboard)/cars/_components/makes/coe-comparison-chart.tsx
+++ b/apps/web/src/app/(dashboard)/cars/_components/makes/coe-comparison-chart.tsx
@@ -5,10 +5,10 @@ import {
   type ChartConfig,
   ChartContainer,
   ChartLegend,
+  ChartLegendContent,
   ChartTooltip,
   ChartTooltipContent,
 } from "@sgcarstrends/ui/components/chart";
-import { ChartDescriptionSection } from "@web/components/charts/shared";
 import type { MakeCoeComparisonData } from "@web/queries/cars/makes/coe-comparison";
 import { formatDateToMonthYear } from "@web/utils/format-date-to-month-year";
 import {
@@ -42,82 +42,78 @@ const chartConfig = {
 
 export const CoeComparisonChart = ({ data }: Props) => {
   return (
-    <div className="flex flex-col gap-4">
-      <ChartContainer config={chartConfig} className="h-[300px] w-full">
-        <ComposedChart
-          accessibilityLayer
-          data={data}
-          aria-label="Dual-axis chart comparing monthly registrations with COE Category A and B premiums"
+    <ChartContainer config={chartConfig} className="h-[300px] w-full">
+      <ComposedChart
+        accessibilityLayer
+        data={data}
+        aria-label="Dual-axis chart comparing monthly registrations with COE Category A and B premiums"
+      >
+        <CartesianGrid vertical={false} />
+        <XAxis
+          dataKey="month"
+          tickFormatter={formatDateToMonthYear}
+          tickMargin={8}
+        />
+
+        {/* Left Y-axis for registrations */}
+        <YAxis yAxisId="registrations" type="number" orientation="left">
+          <Label
+            value="Registrations"
+            angle={-90}
+            position="insideLeft"
+            style={{ textAnchor: "middle" }}
+          />
+        </YAxis>
+
+        {/* Right Y-axis for COE premiums */}
+        <YAxis
+          yAxisId="premium"
+          orientation="right"
+          domain={[
+            (dataMin: number) => Math.floor(dataMin / 10000) * 10000,
+            (dataMax: number) => Math.ceil(dataMax / 10000) * 10000,
+          ]}
+          tickFormatter={numberFormat}
         >
-          <CartesianGrid vertical={false} />
-          <XAxis
-            dataKey="month"
-            tickFormatter={formatDateToMonthYear}
-            tickMargin={8}
+          <Label
+            value="COE Premium (S$)"
+            angle={90}
+            position="insideRight"
+            style={{ textAnchor: "middle" }}
           />
+        </YAxis>
 
-          {/* Left Y-axis for registrations */}
-          <YAxis yAxisId="registrations" type="number" orientation="left">
-            <Label
-              value="Registrations"
-              angle={-90}
-              position="insideLeft"
-              style={{ textAnchor: "middle" }}
-            />
-          </YAxis>
+        <ChartTooltip content={<ChartTooltipContent />} />
 
-          {/* Right Y-axis for COE premiums */}
-          <YAxis
-            yAxisId="premium"
-            orientation="right"
-            domain={[
-              (dataMin: number) => Math.floor(dataMin / 10000) * 10000,
-              (dataMax: number) => Math.ceil(dataMax / 10000) * 10000,
-            ]}
-            tickFormatter={numberFormat}
-          >
-            <Label
-              value="COE Premium (S$)"
-              angle={90}
-              position="insideRight"
-              style={{ textAnchor: "middle" }}
-            />
-          </YAxis>
+        <Bar
+          dataKey="registrations"
+          yAxisId="registrations"
+          fill="var(--primary)"
+          radius={[4, 4, 0, 0]}
+          maxBarSize={40}
+        />
 
-          <ChartTooltip content={<ChartTooltipContent />} />
+        <Line
+          dataKey="categoryAPremium"
+          yAxisId="premium"
+          type="monotone"
+          dot={false}
+          stroke="var(--chart-1)"
+          strokeWidth={2}
+        />
 
-          <Bar
-            dataKey="registrations"
-            yAxisId="registrations"
-            fill="var(--primary)"
-            radius={[4, 4, 0, 0]}
-            maxBarSize={40}
-          />
+        <Line
+          dataKey="categoryBPremium"
+          yAxisId="premium"
+          type="monotone"
+          dot={false}
+          stroke="var(--chart-2)"
+          strokeWidth={2}
+          strokeDasharray="10 10"
+        />
 
-          <Line
-            dataKey="categoryAPremium"
-            yAxisId="premium"
-            type="monotone"
-            dot={false}
-            stroke="var(--chart-1)"
-            strokeWidth={2}
-          />
-
-          <Line
-            dataKey="categoryBPremium"
-            yAxisId="premium"
-            type="monotone"
-            dot={false}
-            stroke="var(--chart-2)"
-            strokeWidth={2}
-            strokeDasharray="10 10"
-          />
-
-          <ChartLegend />
-        </ComposedChart>
-      </ChartContainer>
-
-      <ChartDescriptionSection description="Registration bars (left axis) show monthly vehicle purchases, while COE premium lines (right axis) display Category A and B prices. Rising premiums typically correlate with increased demand, though luxury makes may respond differently to Category B changes versus mass-market makes to Category A." />
-    </div>
+        <ChartLegend content={<ChartLegendContent />} />
+      </ComposedChart>
+    </ChartContainer>
   );
 };

--- a/apps/web/src/app/(dashboard)/cars/_components/makes/coe-comparison-chart.tsx
+++ b/apps/web/src/app/(dashboard)/cars/_components/makes/coe-comparison-chart.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import { numberFormat } from "@ruchernchong/number-format";
+import {
+  type ChartConfig,
+  ChartContainer,
+  ChartLegend,
+  ChartTooltip,
+  ChartTooltipContent,
+} from "@sgcarstrends/ui/components/chart";
+import { ChartDescriptionSection } from "@web/components/charts/shared";
+import type { MakeCoeComparisonData } from "@web/queries/cars/makes/coe-comparison";
+import { formatDateToMonthYear } from "@web/utils/format-date-to-month-year";
+import {
+  Bar,
+  CartesianGrid,
+  ComposedChart,
+  Label,
+  Line,
+  XAxis,
+  YAxis,
+} from "recharts";
+
+interface Props {
+  data: MakeCoeComparisonData[];
+}
+
+const chartConfig = {
+  registrations: {
+    label: "Registrations",
+    color: "var(--chart-1)",
+  },
+  categoryAPremium: {
+    label: "Category A Premium",
+    color: "var(--chart-2)",
+  },
+  categoryBPremium: {
+    label: "Category B Premium",
+    color: "var(--chart-3)",
+  },
+} satisfies ChartConfig;
+
+export const CoeComparisonChart = ({ data }: Props) => {
+  return (
+    <div className="flex flex-col gap-4">
+      <ChartContainer config={chartConfig} className="h-[300px] w-full">
+        <ComposedChart
+          accessibilityLayer
+          data={data}
+          aria-label="Dual-axis chart comparing monthly registrations with COE Category A and B premiums"
+        >
+          <CartesianGrid vertical={false} />
+          <XAxis
+            dataKey="month"
+            tickFormatter={formatDateToMonthYear}
+            tickMargin={8}
+          />
+
+          {/* Left Y-axis for registrations */}
+          <YAxis yAxisId="registrations" type="number" orientation="left">
+            <Label
+              value="Registrations"
+              angle={-90}
+              position="insideLeft"
+              style={{ textAnchor: "middle" }}
+            />
+          </YAxis>
+
+          {/* Right Y-axis for COE premiums */}
+          <YAxis
+            yAxisId="premium"
+            orientation="right"
+            domain={[
+              (dataMin: number) => Math.floor(dataMin / 10000) * 10000,
+              (dataMax: number) => Math.ceil(dataMax / 10000) * 10000,
+            ]}
+            tickFormatter={numberFormat}
+          >
+            <Label
+              value="COE Premium (S$)"
+              angle={90}
+              position="insideRight"
+              style={{ textAnchor: "middle" }}
+            />
+          </YAxis>
+
+          <ChartTooltip content={<ChartTooltipContent />} />
+
+          <Bar
+            dataKey="registrations"
+            yAxisId="registrations"
+            fill="var(--primary)"
+            radius={[4, 4, 0, 0]}
+            maxBarSize={40}
+          />
+
+          <Line
+            dataKey="categoryAPremium"
+            yAxisId="premium"
+            type="monotone"
+            dot={false}
+            stroke="var(--chart-1)"
+            strokeWidth={2}
+          />
+
+          <Line
+            dataKey="categoryBPremium"
+            yAxisId="premium"
+            type="monotone"
+            dot={false}
+            stroke="var(--chart-2)"
+            strokeWidth={2}
+            strokeDasharray="10 10"
+          />
+
+          <ChartLegend />
+        </ComposedChart>
+      </ChartContainer>
+
+      <ChartDescriptionSection description="Registration bars (left axis) show monthly vehicle purchases, while COE premium lines (right axis) display Category A and B prices. Rising premiums typically correlate with increased demand, though luxury makes may respond differently to Category B changes versus mass-market makes to Category A." />
+    </div>
+  );
+};

--- a/apps/web/src/app/(dashboard)/cars/_components/makes/index.ts
+++ b/apps/web/src/app/(dashboard)/cars/_components/makes/index.ts
@@ -1,3 +1,4 @@
+export { CoeComparisonChart } from "./coe-comparison-chart";
 export { MakeCard } from "./make-card";
 export { MakeDetail } from "./make-detail";
 export { MakeDrawer } from "./make-drawer";

--- a/apps/web/src/app/(dashboard)/cars/_components/makes/make-detail.test.tsx
+++ b/apps/web/src/app/(dashboard)/cars/_components/makes/make-detail.test.tsx
@@ -95,7 +95,7 @@ describe("MakeDetail", () => {
     expect(screen.getByText("Past registrations")).toBeVisible();
   });
 
-  it("should render COE Premium Impact card", () => {
+  it("should render Registration vs COE Premium card", () => {
     render(
       <MakeDetail
         make="TOYOTA"
@@ -104,7 +104,7 @@ describe("MakeDetail", () => {
         coeComparison={mockCoeComparison}
       />,
     );
-    expect(screen.getByText("COE Premium Impact")).toBeVisible();
+    expect(screen.getByText("Registration vs COE Premium")).toBeVisible();
     expect(
       screen.getByText("Correlation between registrations and COE premiums"),
     ).toBeVisible();

--- a/apps/web/src/app/(dashboard)/cars/_components/makes/make-detail.test.tsx
+++ b/apps/web/src/app/(dashboard)/cars/_components/makes/make-detail.test.tsx
@@ -10,8 +10,9 @@ vi.mock("next/navigation", () => ({
   }),
 }));
 
-vi.mock("@web/components/makes", () => ({
+vi.mock("@web/app/(dashboard)/cars/_components/makes", () => ({
   MakeTrendChart: () => <div>TrendChart</div>,
+  CoeComparisonChart: () => <div>CoeComparisonChart</div>,
 }));
 
 vi.mock("@web/components/make-selector", () => ({
@@ -53,38 +54,97 @@ const mockMakes: Make[] = ["TOYOTA", "HONDA", "BMW"];
 
 const mockLastUpdated = 1735660800; // 2025-01-01 00:00:00 UTC
 
+const mockCoeComparison = [
+  {
+    month: "2024-01",
+    registrations: 50,
+    categoryAPremium: 95000,
+    categoryBPremium: 110000,
+  },
+  {
+    month: "2024-02",
+    registrations: 30,
+    categoryAPremium: 98000,
+    categoryBPremium: 115000,
+  },
+];
+
 describe("MakeDetail", () => {
-  it("renders make name", () => {
-    render(<MakeDetail make="TOYOTA" cars={mockCars} makes={mockMakes} />);
+  it("should render make name", () => {
+    render(
+      <MakeDetail
+        make="TOYOTA"
+        cars={mockCars}
+        makes={mockMakes}
+        coeComparison={mockCoeComparison}
+      />,
+    );
     expect(screen.getByText("TOYOTA")).toBeVisible();
   });
 
-  it("renders Historical Trend card", () => {
-    render(<MakeDetail make="TOYOTA" cars={mockCars} makes={mockMakes} />);
+  it("should render Historical Trend card", () => {
+    render(
+      <MakeDetail
+        make="TOYOTA"
+        cars={mockCars}
+        makes={mockMakes}
+        coeComparison={mockCoeComparison}
+      />,
+    );
     expect(screen.getByText("Historical Trend")).toBeVisible();
     expect(screen.getByText("Past registrations")).toBeVisible();
   });
 
-  it("renders Summary card", () => {
-    render(<MakeDetail make="TOYOTA" cars={mockCars} makes={mockMakes} />);
+  it("should render COE Premium Impact card", () => {
+    render(
+      <MakeDetail
+        make="TOYOTA"
+        cars={mockCars}
+        makes={mockMakes}
+        coeComparison={mockCoeComparison}
+      />,
+    );
+    expect(screen.getByText("COE Premium Impact")).toBeVisible();
+    expect(
+      screen.getByText("Correlation between registrations and COE premiums"),
+    ).toBeVisible();
+  });
+
+  it("should render Summary card", () => {
+    render(
+      <MakeDetail
+        make="TOYOTA"
+        cars={mockCars}
+        makes={mockMakes}
+        coeComparison={mockCoeComparison}
+      />,
+    );
     expect(screen.getByText("Summary")).toBeVisible();
     expect(
       screen.getByText("Breakdown of fuel & vehicle types by month"),
     ).toBeVisible();
   });
 
-  it("renders NoData component when cars is null", () => {
-    render(<MakeDetail make="TOYOTA" cars={null as any} makes={mockMakes} />);
+  it("should render NoData component when cars is null", () => {
+    render(
+      <MakeDetail
+        make="TOYOTA"
+        cars={null as any}
+        makes={mockMakes}
+        coeComparison={mockCoeComparison}
+      />,
+    );
     expect(screen.getByText("No Data Available")).toBeVisible();
   });
 
-  it("renders LastUpdated component when lastUpdated is provided", () => {
+  it("should render LastUpdated component when lastUpdated is provided", () => {
     render(
       <MakeDetail
         make="TOYOTA"
         cars={mockCars}
         makes={mockMakes}
         lastUpdated={mockLastUpdated}
+        coeComparison={mockCoeComparison}
       />,
     );
     expect(screen.getByText(/Last updated:/)).toBeVisible();
@@ -92,6 +152,7 @@ describe("MakeDetail", () => {
 
   it("should render logo image when logo is provided", () => {
     const mockLogo = {
+      make: "TOYOTA",
       brand: "TOYOTA",
       url: "https://example.com/toyota.png",
       filename: "toyota.png",
@@ -103,6 +164,7 @@ describe("MakeDetail", () => {
         cars={mockCars}
         makes={mockMakes}
         logo={mockLogo}
+        coeComparison={mockCoeComparison}
       />,
     );
 
@@ -112,7 +174,14 @@ describe("MakeDetail", () => {
   });
 
   it("should render placeholder when logo is not provided", () => {
-    render(<MakeDetail make="TOYOTA" cars={mockCars} makes={mockMakes} />);
+    render(
+      <MakeDetail
+        make="TOYOTA"
+        cars={mockCars}
+        makes={mockMakes}
+        coeComparison={mockCoeComparison}
+      />,
+    );
   });
 
   it("should render placeholder when logo download fails", () => {
@@ -122,6 +191,7 @@ describe("MakeDetail", () => {
         cars={mockCars}
         makes={mockMakes}
         logo={undefined}
+        coeComparison={mockCoeComparison}
       />,
     );
   });

--- a/apps/web/src/app/(dashboard)/cars/_components/makes/make-detail.tsx
+++ b/apps/web/src/app/(dashboard)/cars/_components/makes/make-detail.tsx
@@ -1,4 +1,4 @@
-import { Card, CardBody, CardHeader } from "@heroui/card";
+import { Card, CardBody, CardFooter, CardHeader } from "@heroui/card";
 import type { CarLogo } from "@logos/types";
 import type { SelectCar } from "@sgcarstrends/database";
 import { DataTable } from "@sgcarstrends/ui/components/data-table";
@@ -86,6 +86,15 @@ export const MakeDetail = ({
         <CardBody>
           <CoeComparisonChart data={coeComparison} />
         </CardBody>
+        <CardFooter>
+          <p className="text-default-500 text-sm">
+            Registration bars (left axis) show monthly vehicle purchases, while
+            COE premium lines (right axis) display Category A and B prices.
+            Rising premiums typically correlate with increased demand, though
+            luxury makes may respond differently to Category B changes versus
+            mass-market makes to Category A.
+          </p>
+        </CardFooter>
       </Card>
 
       <Card className="p-4">

--- a/apps/web/src/app/(dashboard)/cars/_components/makes/make-detail.tsx
+++ b/apps/web/src/app/(dashboard)/cars/_components/makes/make-detail.tsx
@@ -1,20 +1,18 @@
+import { Card, CardBody, CardHeader } from "@heroui/card";
 import type { CarLogo } from "@logos/types";
 import type { SelectCar } from "@sgcarstrends/database";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@sgcarstrends/ui/components/card";
 import { DataTable } from "@sgcarstrends/ui/components/data-table";
 import { MakeSelector } from "@web/app/(dashboard)/cars/_components/make-selector";
-import { MakeTrendChart } from "@web/app/(dashboard)/cars/_components/makes";
+import {
+  CoeComparisonChart,
+  MakeTrendChart,
+} from "@web/app/(dashboard)/cars/_components/makes";
 import { LastUpdated } from "@web/components/shared/last-updated";
 import NoData from "@web/components/shared/no-data";
 import { columns } from "@web/components/tables/columns/cars-make-columns";
 import Typography from "@web/components/typography";
 import { UnreleasedFeature } from "@web/components/unreleased-feature";
+import type { MakeCoeComparisonData } from "@web/queries/cars/makes/coe-comparison";
 import type { Make } from "@web/types";
 import Image from "next/image";
 
@@ -24,6 +22,7 @@ interface MakeDetailProps {
   makes: Make[];
   lastUpdated?: number | null;
   logo?: CarLogo | null;
+  coeComparison: MakeCoeComparisonData[];
 }
 
 export const MakeDetail = ({
@@ -32,6 +31,7 @@ export const MakeDetail = ({
   makes,
   lastUpdated,
   logo,
+  coeComparison,
 }: MakeDetailProps) => {
   if (!cars) {
     return <NoData />;
@@ -62,25 +62,44 @@ export const MakeDetail = ({
         </div>
       </div>
 
-      <Card>
+      <Card className="p-4">
         <CardHeader>
-          <CardTitle>Historical Trend</CardTitle>
-          <CardDescription>Past registrations</CardDescription>
+          <div className="flex flex-col gap-1">
+            <Typography.H3>Historical Trend</Typography.H3>
+            <Typography.TextSm>Past registrations</Typography.TextSm>
+          </div>
         </CardHeader>
-        <CardContent>
+        <CardBody>
           <MakeTrendChart data={cars.data.toReversed()} />
-        </CardContent>
+        </CardBody>
       </Card>
-      <Card>
+
+      <Card className="p-4">
         <CardHeader>
-          <CardTitle>Summary</CardTitle>
-          <CardDescription>
-            Breakdown of fuel &amp; vehicle types by month
-          </CardDescription>
+          <div className="flex flex-col">
+            <Typography.H3>Registration vs COE Premium</Typography.H3>
+            <Typography.TextSm>
+              Correlation between registrations and COE premiums
+            </Typography.TextSm>
+          </div>
         </CardHeader>
-        <CardContent>
+        <CardBody>
+          <CoeComparisonChart data={coeComparison} />
+        </CardBody>
+      </Card>
+
+      <Card className="p-4">
+        <CardHeader>
+          <div className="flex flex-col gap-1">
+            <Typography.H3>Summary</Typography.H3>
+            <Typography.TextSm>
+              Breakdown of fuel &amp; vehicle types by month
+            </Typography.TextSm>
+          </div>
+        </CardHeader>
+        <CardBody>
           <DataTable columns={columns} data={cars.data} />
-        </CardContent>
+        </CardBody>
       </Card>
     </div>
   );

--- a/apps/web/src/app/(dashboard)/cars/_components/makes/make-trend-chart.tsx
+++ b/apps/web/src/app/(dashboard)/cars/_components/makes/make-trend-chart.tsx
@@ -58,6 +58,7 @@ export const MakeTrendChart = ({ data }: Props) => {
           <Line
             dataKey="count"
             type="monotone"
+            dot={false}
             fill="var(--primary)"
             stroke="var(--primary)"
             strokeWidth={2}

--- a/apps/web/src/app/(dashboard)/cars/makes/@drawer/(.)[make]/page.tsx
+++ b/apps/web/src/app/(dashboard)/cars/makes/@drawer/(.)[make]/page.tsx
@@ -3,6 +3,7 @@
 import { MakeDrawer } from "@web/app/(dashboard)/cars/_components/makes";
 import { MakeDetail } from "@web/app/(dashboard)/cars/_components/makes/make-detail";
 import { fetchMakePageData } from "@web/lib/cars/make-data";
+import { getMakeCoeComparison } from "@web/queries/cars/makes/coe-comparison";
 
 interface Props {
   params: Promise<{ make: string }>;
@@ -11,7 +12,10 @@ interface Props {
 const MakePage = async ({ params }: Props) => {
   const { make } = await params;
 
-  const { cars, makes, lastUpdated } = await fetchMakePageData(make);
+  const [{ cars, makes, lastUpdated }, coeComparison] = await Promise.all([
+    fetchMakePageData(make),
+    getMakeCoeComparison(make),
+  ]);
 
   return (
     <MakeDrawer>
@@ -20,6 +24,7 @@ const MakePage = async ({ params }: Props) => {
         cars={cars}
         makes={makes}
         lastUpdated={lastUpdated}
+        coeComparison={coeComparison}
       />
     </MakeDrawer>
   );

--- a/apps/web/src/app/(dashboard)/cars/makes/[make]/page.tsx
+++ b/apps/web/src/app/(dashboard)/cars/makes/[make]/page.tsx
@@ -11,6 +11,7 @@ import {
   getDistinctMakes,
   getMakeDetails,
 } from "@web/queries/cars";
+import { getMakeCoeComparison } from "@web/queries/cars/makes/coe-comparison";
 import { getCarLogo } from "@web/queries/logos";
 import type { Make } from "@web/types";
 import type { Metadata } from "next";
@@ -52,10 +53,12 @@ export const generateStaticParams = async () => {
 const CarMakePage = async ({ params }: Props) => {
   const { make } = await params;
 
-  const [{ cars, makes, lastUpdated, makeName }, logo] = await Promise.all([
-    fetchMakePageData(make),
-    getCarLogo(make),
-  ]);
+  const [{ cars, makes, lastUpdated, makeName }, logo, coeComparison] =
+    await Promise.all([
+      fetchMakePageData(make),
+      getCarLogo(make),
+      getMakeCoeComparison(make),
+    ]);
 
   const title = `${makeName} Cars Overview: Registration Trends`;
   const description = `${makeName} cars overview. Historical car registration trends and monthly breakdown by fuel and vehicle types in Singapore.`;
@@ -74,6 +77,7 @@ const CarMakePage = async ({ params }: Props) => {
         makes={makes}
         lastUpdated={lastUpdated}
         logo={logo}
+        coeComparison={coeComparison}
       />
     </>
   );

--- a/apps/web/src/app/(dashboard)/coe/_components/pqp/comparison-mixed-chart.tsx
+++ b/apps/web/src/app/(dashboard)/coe/_components/pqp/comparison-mixed-chart.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Card, CardBody, CardHeader } from "@heroui/card";
+import { Card, CardBody, CardFooter, CardHeader } from "@heroui/card";
 import { numberFormat } from "@ruchernchong/number-format";
 import {
   type ChartConfig,
@@ -38,7 +38,7 @@ export const ComparisonMixedChart = ({ data }: Props) => {
           </p>
         </div>
       </CardHeader>
-      <CardBody className="flex flex-col gap-4">
+      <CardBody>
         <ChartContainer config={chartConfig} className="h-[300px] w-full">
           <ComposedChart data={data}>
             <CartesianGrid vertical={false} />
@@ -69,19 +69,14 @@ export const ComparisonMixedChart = ({ data }: Props) => {
             <ChartLegend />
           </ComposedChart>
         </ChartContainer>
-        <div>
-          <div className="text-default-500 text-sm">
-            <h4 className="mb-2 font-semibold text-foreground">
-              Chart Description
-            </h4>
-            <p>
-              Latest COE premium (bars) vs PQP baseline (dashed line). Bars
-              above line indicate strong demand; bars below suggest favourable
-              renewal conditions.
-            </p>
-          </div>
-        </div>
       </CardBody>
+      <CardFooter>
+        <p className="text-default-500 text-sm">
+          Latest COE premium (bars) vs PQP baseline (dashed line). Bars above
+          line indicate strong demand; bars below suggest favourable renewal
+          conditions.
+        </p>
+      </CardFooter>
     </Card>
   );
 };

--- a/apps/web/src/app/(dashboard)/coe/_components/pqp/trends-chart.tsx
+++ b/apps/web/src/app/(dashboard)/coe/_components/pqp/trends-chart.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Card, CardBody, CardHeader } from "@heroui/card";
+import { Card, CardBody, CardFooter, CardHeader } from "@heroui/card";
 import { numberFormat } from "@ruchernchong/number-format";
 import {
   type ChartConfig,
@@ -9,7 +9,6 @@ import {
   ChartTooltip,
   ChartTooltipContent,
 } from "@sgcarstrends/ui/components/chart";
-import { ChartDescriptionSection } from "@web/components/charts/shared";
 import type { Pqp } from "@web/types/coe";
 import { formatDateToMonthYear } from "@web/utils/format-date-to-month-year";
 import { CartesianGrid, Line, LineChart, XAxis, YAxis } from "recharts";
@@ -64,8 +63,13 @@ export const TrendsChart = ({ data }: Props) => {
             <ChartLegend />
           </LineChart>
         </ChartContainer>
-        <ChartDescriptionSection description="Historical PQP rates (3-month average COE prices) used for COE renewals across categories." />
       </CardBody>
+      <CardFooter>
+        <p className="text-default-500 text-sm">
+          Historical PQP rates (3-month average COE prices) used for COE
+          renewals across categories.
+        </p>
+      </CardFooter>
     </Card>
   );
 };

--- a/apps/web/src/components/__tests__/charts-shared.test.tsx
+++ b/apps/web/src/components/__tests__/charts-shared.test.tsx
@@ -1,6 +1,5 @@
 import { render, screen } from "@testing-library/react";
 import {
-  ChartDescriptionSection,
   currencyTooltipFormatter,
   MonthXAxis,
   PriceYAxis,
@@ -8,7 +7,7 @@ import {
 import { Line, LineChart } from "recharts";
 
 describe("Chart shared helpers", () => {
-  it("formats currency tooltip content with matching colour indicator", () => {
+  it("should format currency tooltip content with matching colour indicator", () => {
     const fragment = currencyTooltipFormatter({
       value: 123456,
       name: "COE Premium",
@@ -20,7 +19,7 @@ describe("Chart shared helpers", () => {
     expect(screen.getByText("$123,456")).toBeInTheDocument();
   });
 
-  it("renders axis helpers without crashing", () => {
+  it("should render axis helpers without crashing", () => {
     render(
       <LineChart
         width={400}
@@ -34,19 +33,5 @@ describe("Chart shared helpers", () => {
     );
 
     expect(document.querySelector("svg")).toBeTruthy();
-  });
-
-  it("renders a chart description section", () => {
-    render(
-      <ChartDescriptionSection
-        title="Trend insight"
-        description="COE premiums are stabilising."
-      />,
-    );
-
-    expect(screen.getByText("Trend insight")).toBeInTheDocument();
-    expect(
-      screen.getByText("COE premiums are stabilising."),
-    ).toBeInTheDocument();
   });
 });

--- a/apps/web/src/components/charts/shared.tsx
+++ b/apps/web/src/components/charts/shared.tsx
@@ -72,22 +72,3 @@ interface MonthXAxisProps {
 export const MonthXAxis = ({ tickFormatter }: MonthXAxisProps) => (
   <XAxis dataKey="month" tickFormatter={tickFormatter} axisLine={false} />
 );
-
-interface ChartDescriptionSectionProps {
-  title?: string;
-  description: string;
-  className?: string;
-}
-
-export const ChartDescriptionSection = ({
-  title = "Chart Description",
-  description,
-  className = "",
-}: ChartDescriptionSectionProps) => (
-  <div className={className}>
-    <div className="text-default-500 text-sm">
-      <h4 className="mb-2 font-semibold text-foreground">{title}</h4>
-      <p>{description}</p>
-    </div>
-  </div>
-);

--- a/apps/web/src/queries/cars/makes/coe-comparison.ts
+++ b/apps/web/src/queries/cars/makes/coe-comparison.ts
@@ -1,0 +1,104 @@
+import { cars, coe, db } from "@sgcarstrends/database";
+import { CACHE_LIFE, CACHE_TAG } from "@web/lib/cache";
+import type { COECategory } from "@web/types";
+import { subMonths } from "date-fns";
+import { and, desc, gte, inArray, lte, sql } from "drizzle-orm";
+import { cacheLife, cacheTag } from "next/cache";
+
+export interface MakeCoeComparisonData {
+  month: string;
+  registrations: number;
+  categoryAPremium: number;
+  categoryBPremium: number;
+}
+
+const getDateRange24Months = () => {
+  const currentDate = new Date();
+  const startDate = subMonths(currentDate, 24);
+
+  const startMonth = startDate.toISOString().slice(0, 7);
+  const endMonth = currentDate.toISOString().slice(0, 7);
+
+  return { startMonth, endMonth };
+};
+
+export const getMakeCoeComparison = async (
+  make: string,
+): Promise<MakeCoeComparisonData[]> => {
+  "use cache";
+  cacheLife(CACHE_LIFE.monthlyData);
+
+  const { startMonth, endMonth } = getDateRange24Months();
+  cacheTag(
+    ...CACHE_TAG.cars.makes(make),
+    ...CACHE_TAG.coe.range(startMonth, endMonth),
+  );
+
+  const pattern = make.replaceAll("-", "%");
+
+  // Fetch make registrations by month
+  const makeRegistrations = await db
+    .select({
+      month: cars.month,
+      count: sql<number>`sum(${cars.number})`.mapWith(Number),
+    })
+    .from(cars)
+    .where(
+      and(
+        sql`lower(${cars.make}) LIKE lower(${pattern})`,
+        gte(cars.month, startMonth),
+        lte(cars.month, endMonth),
+      ),
+    )
+    .groupBy(cars.month)
+    .orderBy(desc(cars.month));
+
+  // Fetch COE premiums for both Category A and B
+  const coePremiums = await db
+    .select({
+      month: coe.month,
+      vehicleClass: coe.vehicleClass,
+      premium: coe.premium,
+      biddingNo: coe.biddingNo,
+    })
+    .from(coe)
+    .where(
+      and(
+        gte(coe.month, startMonth),
+        lte(coe.month, endMonth),
+        inArray(coe.vehicleClass, ["Category A", "Category B"]),
+      ),
+    )
+    .orderBy(desc(coe.month), desc(coe.biddingNo));
+
+  // Get latest bidding per month for each category
+  const coeByMonth = new Map<
+    string,
+    { categoryA: number; categoryB: number }
+  >();
+
+  for (const result of coePremiums) {
+    const monthData = coeByMonth.get(result.month) ?? {
+      categoryA: 0,
+      categoryB: 0,
+    };
+
+    // Only update if this is a higher bidding number (latest)
+    const category = result.vehicleClass as COECategory;
+
+    if (category === "Category A" && monthData.categoryA === 0) {
+      monthData.categoryA = result.premium;
+    } else if (category === "Category B" && monthData.categoryB === 0) {
+      monthData.categoryB = result.premium;
+    }
+
+    coeByMonth.set(result.month, monthData);
+  }
+
+  return makeRegistrations.map(({ month, count }) => ({
+    month,
+    registrations: count,
+    categoryAPremium: coeByMonth.get(month)?.categoryA ?? 0,
+    categoryBPremium: coeByMonth.get(month)?.categoryB ?? 0,
+  }));
+};


### PR DESCRIPTION
## Summary
- Added COE premium comparison chart to make pages showing COE price trends for relevant vehicle classes
- Refactored chart descriptions to use CardFooter component for consistent positioning