### PR TITLE
refactor: consolidate data loaders

### DIFF
--- a/apps/web/src/app/(dashboard)/(home)/page.tsx
+++ b/apps/web/src/app/(dashboard)/(home)/page.tsx
@@ -6,9 +6,7 @@ import { TopMakesByYear } from "@web/components/top-makes-by-year";
 import { TotalNewCarRegistrationsByYear } from "@web/components/total-new-car-registrations-by-year";
 import Typography from "@web/components/typography";
 import { SITE_TITLE, SITE_URL } from "@web/config";
-import { getAllPosts } from "@web/lib/data/posts";
-import { getTopMakesByYear, getYearlyRegistrations } from "@web/queries/cars";
-import { getAllCoeCategoryTrends, getLatestCoeResults } from "@web/queries/coe";
+import { loadHomePageData } from "@web/lib/home/page-data";
 import type { Metadata } from "next";
 import Link from "next/link";
 import type { WebSite, WithContext } from "schema-dts";
@@ -29,14 +27,8 @@ export const metadata: Metadata = {
 };
 
 const HomePage = async () => {
-  const [coeTrends, yearlyData, latestTopMakes, allPosts, latestCoe] =
-    await Promise.all([
-      getAllCoeCategoryTrends(),
-      getYearlyRegistrations(),
-      getTopMakesByYear(),
-      getAllPosts(),
-      getLatestCoeResults(),
-    ]);
+  const { coeTrends, yearlyData, latestTopMakes, allPosts, latestCoe } =
+    await loadHomePageData();
   const latestYear = yearlyData.at(-1)?.year;
   const structuredData: WithContext<WebSite> = {
     "@context": "https://schema.org",

--- a/apps/web/src/app/(dashboard)/cars/[category]/page.tsx
+++ b/apps/web/src/app/(dashboard)/cars/[category]/page.tsx
@@ -1,17 +1,12 @@
-import { redis } from "@sgcarstrends/utils";
 import { loadSearchParams } from "@web/app/(dashboard)/cars/search-params";
 import { PageHeader } from "@web/components/page-header";
 import { StructuredData } from "@web/components/structured-data";
 import Typography from "@web/components/typography";
-import { LAST_UPDATED_CARS_KEY, SITE_TITLE, SITE_URL } from "@web/config";
+import { SITE_TITLE, SITE_URL } from "@web/config";
+import { loadCarsCategoryPageData } from "@web/lib/cars/page-data";
 import { createPageMetadata } from "@web/lib/metadata";
-import {
-  getCarMarketShareData,
-  getCarsData,
-  getCarTopPerformersData,
-} from "@web/queries/cars";
 import { formatDateToMonthYear } from "@web/utils/format-date-to-month-year";
-import { fetchMonthsForCars, getMonthOrLatest } from "@web/utils/months";
+import { getMonthOrLatest } from "@web/utils/months";
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import type { SearchParams } from "nuqs/server";
@@ -95,14 +90,8 @@ const CategoryPage = async ({ params, searchParams }: Props) => {
   let { month } = await loadSearchParams(searchParams);
   month = await getMonthOrLatest(month, "cars");
 
-  const months = await fetchMonthsForCars();
-
-  const [lastUpdated, cars, topPerformers, marketShare] = await Promise.all([
-    redis.get<number>(LAST_UPDATED_CARS_KEY),
-    getCarsData(month),
-    getCarTopPerformersData(month),
-    getCarMarketShareData(month, config.apiDataField),
-  ]);
+  const { lastUpdated, cars, topPerformers, marketShare, months } =
+    await loadCarsCategoryPageData(month, config.apiDataField);
 
   const categoryData = cars?.[config.apiDataField] || [];
 

--- a/apps/web/src/app/(dashboard)/coe/page.tsx
+++ b/apps/web/src/app/(dashboard)/coe/page.tsx
@@ -8,21 +8,16 @@ import {
   CardTitle,
 } from "@sgcarstrends/ui/components/card";
 import { Progress } from "@sgcarstrends/ui/components/progress";
-import { redis } from "@sgcarstrends/utils";
 import { AnimatedNumber } from "@web/components/animated-number";
 import { LatestCoePremium } from "@web/components/coe/latest-coe-premium";
 import { PageHeader } from "@web/components/page-header";
 import { StructuredData } from "@web/components/structured-data";
 import Typography from "@web/components/typography";
-import { LAST_UPDATED_COE_KEY, SITE_TITLE, SITE_URL } from "@web/config";
+import { SITE_TITLE, SITE_URL } from "@web/config";
 import { calculateOverviewStats } from "@web/lib/coe/calculations";
+import { loadCOEOverviewPageData } from "@web/lib/coe/page-data";
 import { createPageMetadata } from "@web/lib/metadata";
-import {
-  getCoeCategoryTrends,
-  getCoeResults,
-  getLatestCoeResults,
-  getPqpRates,
-} from "@web/queries/coe";
+import { getLatestCoeResults } from "@web/queries/coe";
 import { formatPercent } from "@web/utils/charts";
 import { formatDateToMonthYear } from "@web/utils/format-date-to-month-year";
 import type { Metadata } from "next";
@@ -55,29 +50,8 @@ export const generateMetadata = async (): Promise<Metadata> => {
 };
 
 const COEPricesPage = async () => {
-  // Fetch COE trends for all categories in parallel
-  const trendResults = await Promise.all([
-    getCoeCategoryTrends("Category A"),
-    getCoeCategoryTrends("Category B"),
-    getCoeCategoryTrends("Category C"),
-    getCoeCategoryTrends("Category D"),
-    getCoeCategoryTrends("Category E"),
-  ]);
-
-  const coeTrends = {
-    "Category A": trendResults[0],
-    "Category B": trendResults[1],
-    "Category C": trendResults[2],
-    "Category D": trendResults[3],
-    "Category E": trendResults[4],
-  };
-
-  const [latestResults, allCoeResults, pqpRates] = await Promise.all([
-    getLatestCoeResults(),
-    getCoeResults(),
-    getPqpRates(),
-  ]);
-  const lastUpdated = await redis.get<number>(LAST_UPDATED_COE_KEY);
+  const { coeTrends, latestResults, allCoeResults, pqpRates, lastUpdated } =
+    await loadCOEOverviewPageData();
 
   const structuredData: WithContext<WebPage> = {
     "@context": "https://schema.org",

--- a/apps/web/src/lib/cars/page-data.ts
+++ b/apps/web/src/lib/cars/page-data.ts
@@ -1,0 +1,110 @@
+import { loadLastUpdated } from "@web/lib/common";
+import {
+  getCarMarketShareData,
+  getCarsComparison,
+  getCarsData,
+  getCarTopPerformersData,
+  getFuelTypeData,
+  getTopMakesByFuelType,
+  getTopTypes,
+  getVehicleTypeData,
+} from "@web/queries/cars";
+import { fetchMonthsForCars } from "@web/utils/months";
+
+/**
+ * Load data for the main cars overview page
+ *
+ * @param month - Month in YYYY-MM format
+ * @returns Cars data, comparison, top types, top makes, and available months
+ */
+export const loadCarsPageData = async (month: string) => {
+  const [cars, comparison, topTypes, topMakes, months] = await Promise.all([
+    getCarsData(month),
+    getCarsComparison(month),
+    getTopTypes(month),
+    getTopMakesByFuelType(month),
+    fetchMonthsForCars(),
+  ]);
+
+  return { cars, comparison, topTypes, topMakes, months };
+};
+
+/**
+ * Load data for cars category pages (fuel-types or vehicle-types)
+ *
+ * @param month - Month in YYYY-MM format
+ * @param apiDataField - Category field to fetch market share for
+ * @returns Category page data with cars, top performers, market share, months, and last updated
+ */
+export const loadCarsCategoryPageData = async (
+  month: string,
+  apiDataField: "fuelType" | "vehicleType",
+) => {
+  const [lastUpdated, cars, topPerformers, marketShare, months] =
+    await Promise.all([
+      loadLastUpdated("cars"),
+      getCarsData(month),
+      getCarTopPerformersData(month),
+      getCarMarketShareData(month, apiDataField),
+      fetchMonthsForCars(),
+    ]);
+
+  return { lastUpdated, cars, topPerformers, marketShare, months };
+};
+
+/**
+ * Type definition for fuel/vehicle type data
+ */
+export interface TypeData {
+  total: number;
+  data: {
+    month: string;
+    make: string;
+    fuelType?: string;
+    vehicleType?: string;
+    count: number;
+  }[];
+}
+
+/**
+ * Load data for specific car type pages (fuel-type or vehicle-type detail)
+ *
+ * @param category - Category type ('fuel-types' or 'vehicle-types')
+ * @param type - Specific type slug
+ * @param month - Month in YYYY-MM format
+ * @returns Type-safe data for the specific type page
+ */
+export const loadCarsTypePageData = async (
+  category: string,
+  type: string,
+  month: string,
+): Promise<{
+  cars: TypeData;
+  months: string[];
+  lastUpdated: number | null;
+}> => {
+  const [cars, months, lastUpdated] = await Promise.all([
+    category === "fuel-types"
+      ? getFuelTypeData(type, month)
+      : getVehicleTypeData(type, month),
+    fetchMonthsForCars(),
+    loadLastUpdated("cars"),
+  ]);
+
+  return { cars, months, lastUpdated };
+};
+
+/**
+ * Load metadata data for cars overview page
+ *
+ * @param month - Month in YYYY-MM format
+ * @returns Top types and car registration data for metadata generation
+ */
+export const loadCarsMetadataData = async (month: string) => {
+  const [topTypes, carRegistration] = await Promise.all([
+    getTopTypes(month),
+    getCarsData(month),
+  ]);
+
+  return { topTypes, carRegistration };
+};

--- a/apps/web/src/lib/coe/page-data.ts
+++ b/apps/web/src/lib/coe/page-data.ts
@@ -5,7 +5,15 @@ import {
 } from "@web/app/(dashboard)/coe/search-params";
 import { LAST_UPDATED_COE_KEY } from "@web/config";
 import { groupCOEResultsByBidding } from "@web/lib/coe/calculations";
-import { getCoeMonths, getCoeResultsFiltered } from "@web/queries/coe";
+import { loadLastUpdated } from "@web/lib/common";
+import {
+  getCoeCategoryTrends,
+  getCoeMonths,
+  getCoeResults,
+  getCoeResultsFiltered,
+  getLatestCoeResults,
+  getPqpRates,
+} from "@web/queries/coe";
 
 export const fetchCOEPageData = async (start?: string, end?: string) => {
   const defaultStart = await getDefaultStartDate();
@@ -24,5 +32,50 @@ export const fetchCOEPageData = async (start?: string, end?: string) => {
     months: monthsResult.map(({ month }) => month),
     lastUpdated,
     data: groupCOEResultsByBidding(coeResults),
+  };
+};
+
+/**
+ * Load all data for the COE overview page
+ *
+ * @returns COE trends by category, latest results, all results, PQP rates, and last updated timestamp
+ */
+export const loadCOEOverviewPageData = async () => {
+  const [
+    trendA,
+    trendB,
+    trendC,
+    trendD,
+    trendE,
+    latestResults,
+    allCoeResults,
+    pqpRates,
+    lastUpdated,
+  ] = await Promise.all([
+    getCoeCategoryTrends("Category A"),
+    getCoeCategoryTrends("Category B"),
+    getCoeCategoryTrends("Category C"),
+    getCoeCategoryTrends("Category D"),
+    getCoeCategoryTrends("Category E"),
+    getLatestCoeResults(),
+    getCoeResults(),
+    getPqpRates(),
+    loadLastUpdated("coe"),
+  ]);
+
+  const coeTrends = {
+    "Category A": trendA,
+    "Category B": trendB,
+    "Category C": trendC,
+    "Category D": trendD,
+    "Category E": trendE,
+  };
+
+  return {
+    coeTrends,
+    latestResults,
+    allCoeResults,
+    pqpRates,
+    lastUpdated,
   };
 };

--- a/apps/web/src/lib/common.ts
+++ b/apps/web/src/lib/common.ts
@@ -1,0 +1,15 @@
+import { redis } from "@sgcarstrends/utils";
+import { LAST_UPDATED_CARS_KEY, LAST_UPDATED_COE_KEY } from "@web/config";
+
+/**
+ * Load last updated timestamp for cars or COE data from Redis cache
+ *
+ * @param type - Data type to check ('cars' or 'coe')
+ * @returns Last updated timestamp in milliseconds, or null if not available
+ */
+export const loadLastUpdated = async (
+  type: "cars" | "coe",
+): Promise<number | null> => {
+  const key = type === "cars" ? LAST_UPDATED_CARS_KEY : LAST_UPDATED_COE_KEY;
+  return redis.get<number>(key);
+};

--- a/apps/web/src/lib/home/page-data.ts
+++ b/apps/web/src/lib/home/page-data.ts
@@ -1,0 +1,27 @@
+import { getAllPosts } from "@web/lib/data/posts";
+import { getTopMakesByYear, getYearlyRegistrations } from "@web/queries/cars";
+import { getAllCoeCategoryTrends, getLatestCoeResults } from "@web/queries/coe";
+
+/**
+ * Load all data for the home page
+ *
+ * @returns COE trends, yearly car data, top makes, blog posts, and latest COE results
+ */
+export const loadHomePageData = async () => {
+  const [coeTrends, yearlyData, latestTopMakes, allPosts, latestCoe] =
+    await Promise.all([
+      getAllCoeCategoryTrends(),
+      getYearlyRegistrations(),
+      getTopMakesByYear(),
+      getAllPosts(),
+      getLatestCoeResults(),
+    ]);
+
+  return {
+    coeTrends,
+    yearlyData,
+    latestTopMakes,
+    allPosts,
+    latestCoe,
+  };
+};


### PR DESCRIPTION
## Summary
- Extracted reusable data loaders to eliminate Promise.all() duplication across pages
- Removed type assertions and improved type safety in cars/[category]/[type]/page.tsx