### PR TITLE
Implement granular cache tags for precise invalidation

### DIFF
--- a/apps/api/CLAUDE.md
+++ b/apps/api/CLAUDE.md
@@ -80,11 +80,33 @@ The API follows a feature-based architecture in `src/features/`:
 
 The API uses a workflow-based system for data processing:
 
-- **Workflow Runtime** (`src/lib/workflows/workflow.ts`): Common workflow helpers, step runner, Redis timestamps
+- **Workflow Runtime** (`src/lib/workflows/workflow.ts`): Common workflow helpers, step runner, Redis timestamps, cache revalidation
 - **Data Updaters** (`src/lib/workflows/update-cars.ts`, `src/lib/workflows/update-coe.ts`): Automated data fetching and processing
 - **Blog Generation** (`src/lib/workflows/posts.ts`): Orchestrates LLM-powered blog post creation using `@sgcarstrends/ai` package
 - **Main Workflows** (`src/lib/workflows/cars.ts`, `src/lib/workflows/coe.ts`): Main workflow orchestrators exposed as routes
 - **Social Publishing**: Automated posting to platforms when data updates occur
+- **Cache Revalidation**: Triggers granular cache invalidation on the web app after data updates
+
+### Cache Revalidation
+
+Workflows invalidate web app caches using granular cache tags via the `revalidateWebCache()` helper:
+
+**Cars Workflow** invalidates:
+- `cars:month:{month}` - Specific month's data
+- `cars:year:{year}` - Year-specific data
+- `cars:months` - Available months list
+- `cars:makes` - Makes list (in case new makes appear)
+- `cars:annual` - Annual totals
+- `posts:list` - Blog post list (when new post generated)
+
+**COE Workflow** invalidates:
+- `coe:results` - All COE results
+- `coe:latest` - Latest COE results
+- `coe:months` - Available COE months
+- `coe:year:{year}` - Year-specific data
+- `posts:list` - Blog post list (when new post generated)
+
+See `apps/web/CLAUDE.md` for complete cache tag documentation and the web app's `/api/revalidate` endpoint.
 
 ### Authentication & Security
 

--- a/apps/api/src/lib/workflows/cars.ts
+++ b/apps/api/src/lib/workflows/cars.ts
@@ -35,14 +35,21 @@ export const carsWorkflow = createWorkflow(
     const { month } = await getCarsLatestMonth();
 
     // Invalidate cache for updated car data
-    await revalidateWebCache(context, ["cars"]);
+    const year = month.split("-")[0];
+    await revalidateWebCache(context, [
+      `cars:month:${month}`,
+      `cars:year:${year}`,
+      "cars:months",
+      "cars:makes",
+      "cars:annual",
+    ]);
 
     const post = await generateCarPost(context, month);
 
     // Announce new blog post on social media
     if (post?.success && post?.title) {
       // Invalidate cache for new blog post
-      await revalidateWebCache(context, ["posts"]);
+      await revalidateWebCache(context, ["posts:list"]);
 
       const link = `${SITE_URL}/blog/${post.slug}`;
       const message = `📰 New Blog Post: ${post.title}`;

--- a/apps/api/src/lib/workflows/coe.ts
+++ b/apps/api/src/lib/workflows/coe.ts
@@ -37,7 +37,13 @@ export const coeWorkflow = createWorkflow(
     const { month, biddingNo } = await getCoeLatestMonth();
 
     // Invalidate cache for updated COE data
-    await revalidateWebCache(context, ["coe"]);
+    const year = month.split("-")[0];
+    await revalidateWebCache(context, [
+      "coe:results",
+      "coe:latest",
+      "coe:months",
+      `coe:year:${year}`,
+    ]);
 
     // Generate blog post only when both bidding exercises are complete (biddingNo = 2)
     if (biddingNo === 2) {
@@ -46,7 +52,7 @@ export const coeWorkflow = createWorkflow(
       // Announce new blog post on social media
       if (post?.success && post?.title) {
         // Invalidate cache for new blog post
-        await revalidateWebCache(context, ["posts"]);
+        await revalidateWebCache(context, ["posts:list"]);
 
         const link = `${SITE_URL}/blog/${post.slug}`;
         const message = `📰 New Blog Post: ${post.title}`;

--- a/apps/web/CLAUDE.md
+++ b/apps/web/CLAUDE.md
@@ -158,20 +158,41 @@ The application implements Next.js 16 Cache Components with `"use cache"` direct
 
 - **Cache Directives**: All data fetching queries use `"use cache"` with `cacheLife("max")` for monthly data
 - **Cache Profile**: Custom "max" profile optimized for CPU efficiency (30-day revalidation aligned with monthly updates)
-- **Cache Tags**: Domain-level scopes (`CACHE_TAG.CARS`, `CACHE_TAG.COE`, `CACHE_TAG.POSTS`) for on-demand invalidation
+- **Cache Tags**: Granular tags for precise on-demand invalidation (e.g., `cars:month:2024-01`, `coe:period:12m`)
 - **Tagged Queries**: All queries include cache tags for manual revalidation via `revalidateTag()`
-- **Cache Configuration**:
-  - `next.config.ts`: Custom "max" profile with 30-day stale/revalidate, 1-year expire
-  - `src/lib/cache.ts`: Defines cache tag constants for cars, COE, and posts domains
+- **Cache Configuration**: `next.config.ts` defines custom "max" profile with 30-day stale/revalidate, 1-year expire
 - **Revalidation Strategy**: On-demand via `revalidateTag()` when monthly data arrives (bypasses 30-day cache)
+
+**Cache Tag Patterns**:
+
+Granular cache tags enable precise invalidation without over-fetching:
+
+| Tag Pattern | Description | Example |
+|-------------|-------------|---------|
+| `cars:month:{month}` | Month-specific car data | `cars:month:2024-01` |
+| `cars:year:{year}` | Year-specific car data | `cars:year:2024` |
+| `cars:make:{make}` | Make-specific car data | `cars:make:toyota` |
+| `cars:fuel:{fuelType}` | Fuel type-specific data | `cars:fuel:electric` |
+| `cars:vehicle:{vehicleType}` | Vehicle type-specific data | `cars:vehicle:saloon` |
+| `cars:category:{category}` | Category-specific data | `cars:category:saloon` |
+| `cars:makes` | Car makes list | - |
+| `cars:months` | Available months list | - |
+| `cars:annual` | Yearly registration totals | - |
+| `coe:results` | All COE results | - |
+| `coe:period:{period}` | Period-filtered COE data | `coe:period:12m` |
+| `coe:category:{category}` | Category-specific COE data | `coe:category:A` |
+| `coe:year:{year}` | Year-specific COE data | `coe:year:2024` |
+| `coe:months` | Available COE months list | - |
+| `coe:pqp` | PQP rates data | - |
+| `posts:list` | Blog post list | - |
+| `posts:slug:{slug}` | Individual blog post | `posts:slug:jan-2024-analysis` |
 
 **Cache Strategy Best Practices**:
 
 - Use `"use cache"` directive at the top of async functions that fetch data
 - Apply `cacheLife("max")` for monthly data (30-day client/server cache)
-- Tag with domain-level scopes (`cacheTag(CACHE_TAG.CARS)`) for on-demand invalidation
-- Trigger `revalidateTag()` when new monthly data arrives to bypass automatic revalidation
-- Avoid over-granular tags to minimize ISR write overhead
+- Tag with granular scopes based on query parameters for precise invalidation
+- Trigger `revalidateTag()` when new data arrives to bypass automatic revalidation
 - See `cache-components` skill for implementation patterns
 
 **CPU Optimization**:
@@ -183,18 +204,36 @@ The custom "max" profile minimizes Vercel Fluid Compute usage:
 - **On-demand revalidation**: Manual `revalidateTag()` triggers immediate cache refresh when new data arrives
 - **Result**: ~2 regenerations/month (1 automatic + 1 manual) vs ~30 with daily checks = **15x CPU savings**
 
-**Cache Implementation Example**:
+**Cache Implementation Examples**:
 
 ```typescript
-import {CACHE_TAG} from "@web/lib/cache";
 import {cacheLife, cacheTag} from "next/cache";
 
+// Static list query - uses simple tag
 export const getDistinctMakes = async () => {
     "use cache";
-    cacheLife("max");  // Uses custom 30-day profile from next.config.ts
-    cacheTag(CACHE_TAG.CARS);  // Enables on-demand revalidation
+    cacheLife("max");
+    cacheTag("cars:makes");  // Static tag for makes list
 
     return db.selectDistinct({make: cars.make}).from(cars).orderBy(cars.make);
+};
+
+// Parameterised query - uses dynamic tag
+export const getTopTypes = async (month: string) => {
+    "use cache";
+    cacheLife("max");
+    cacheTag(`cars:month:${month}`);  // Dynamic tag includes parameter
+
+    return db.select(...).from(cars).where(eq(cars.month, month));
+};
+
+// Multiple parameters - uses multiple tags
+export const getCarMarketShareData = async (month: string, category: string) => {
+    "use cache";
+    cacheLife("max");
+    cacheTag(`cars:month:${month}`, `cars:category:${category}`);
+
+    // Query implementation
 };
 ```
 
@@ -202,21 +241,33 @@ This pattern is used across all query functions in `src/queries/cars/` and `src/
 
 **On-demand Cache Revalidation**:
 
-When new monthly data arrives, trigger cache invalidation:
+When new monthly data arrives, trigger targeted cache invalidation:
 
 ```typescript
-// In API route or server action
 import {revalidateTag} from "next/cache";
-import {CACHE_TAG} from "@web/lib/cache";
 
-// Invalidate all car data queries
-revalidateTag(CACHE_TAG.CARS);
+// Invalidate specific month's car data
+revalidateTag("cars:month:2024-01");
 
-// Invalidate all COE data queries
-revalidateTag(CACHE_TAG.COE);
+// Invalidate specific make's data
+revalidateTag("cars:make:toyota");
+
+// Invalidate COE results for a specific period
+revalidateTag("coe:period:12m");
+
+// Invalidate COE category data
+revalidateTag("coe:category:A");
+
+// Invalidate PQP rates
+revalidateTag("coe:pqp");
+
+// Invalidate static lists when new data adds new entries
+revalidateTag("cars:makes");
+revalidateTag("cars:months");
+revalidateTag("coe:months");
 ```
 
-This immediately clears client and server caches, bypassing the 30-day automatic revalidation period
+This precisely invalidates only affected caches, avoiding unnecessary regeneration of unrelated queries.
 
 **Data Queries**: Organized in `src/queries/` directory with comprehensive test coverage:
 

--- a/apps/web/CLAUDE.md
+++ b/apps/web/CLAUDE.md
@@ -179,6 +179,7 @@ Granular cache tags enable precise invalidation without over-fetching:
 | `cars:months` | Available months list | - |
 | `cars:annual` | Yearly registration totals | - |
 | `coe:results` | All COE results | - |
+| `coe:latest` | Latest COE results | - |
 | `coe:period:{period}` | Period-filtered COE data | `coe:period:12m` |
 | `coe:category:{category}` | Category-specific COE data | `coe:category:A` |
 | `coe:year:{year}` | Year-specific COE data | `coe:year:2024` |
@@ -241,30 +242,35 @@ This pattern is used across all query functions in `src/queries/cars/` and `src/
 
 **On-demand Cache Revalidation**:
 
-When new monthly data arrives, trigger targeted cache invalidation:
+When new monthly data arrives, trigger targeted cache invalidation. In Next.js 16, `revalidateTag()` requires a second
+argument specifying the cache profile (use `"max"` for stale-while-revalidate semantics):
 
 ```typescript
 import {revalidateTag} from "next/cache";
 
 // Invalidate specific month's car data
-revalidateTag("cars:month:2024-01");
+revalidateTag("cars:month:2024-01", "max");
 
 // Invalidate specific make's data
-revalidateTag("cars:make:toyota");
+revalidateTag("cars:make:toyota", "max");
+
+// Invalidate COE results
+revalidateTag("coe:results", "max");
+revalidateTag("coe:latest", "max");
 
 // Invalidate COE results for a specific period
-revalidateTag("coe:period:12m");
+revalidateTag("coe:period:12m", "max");
 
 // Invalidate COE category data
-revalidateTag("coe:category:A");
+revalidateTag("coe:category:A", "max");
 
 // Invalidate PQP rates
-revalidateTag("coe:pqp");
+revalidateTag("coe:pqp", "max");
 
 // Invalidate static lists when new data adds new entries
-revalidateTag("cars:makes");
-revalidateTag("cars:months");
-revalidateTag("coe:months");
+revalidateTag("cars:makes", "max");
+revalidateTag("cars:months", "max");
+revalidateTag("coe:months", "max");
 ```
 
 This precisely invalidates only affected caches, avoiding unnecessary regeneration of unrelated queries.

--- a/apps/web/src/app/(dashboard)/(home)/page.tsx
+++ b/apps/web/src/app/(dashboard)/(home)/page.tsx
@@ -6,10 +6,8 @@ import { TopMakesByYear } from "@web/components/top-makes-by-year";
 import { TotalNewCarRegistrationsByYear } from "@web/components/total-new-car-registrations-by-year";
 import Typography from "@web/components/typography";
 import { SITE_TITLE, SITE_URL } from "@web/config";
-import { CACHE_TAG } from "@web/lib/cache";
 import { loadHomePageData } from "@web/lib/home/page-data";
 import type { Metadata } from "next";
-import { cacheLife, cacheTag } from "next/cache";
 import Link from "next/link";
 import type { WebSite, WithContext } from "schema-dts";
 
@@ -29,10 +27,6 @@ export const metadata: Metadata = {
 };
 
 const HomePage = async () => {
-  "use cache";
-  cacheLife("max");
-  cacheTag(CACHE_TAG.CARS, CACHE_TAG.COE, CACHE_TAG.POSTS);
-
   const { coeTrends, yearlyData, latestTopMakes, allPosts, latestCoe } =
     await loadHomePageData();
   const latestYear = yearlyData.at(-1)?.year;

--- a/apps/web/src/app/(dashboard)/coe/page.tsx
+++ b/apps/web/src/app/(dashboard)/coe/page.tsx
@@ -14,7 +14,6 @@ import { PageHeader } from "@web/components/page-header";
 import { StructuredData } from "@web/components/structured-data";
 import Typography from "@web/components/typography";
 import { SITE_TITLE, SITE_URL } from "@web/config";
-import { CACHE_TAG } from "@web/lib/cache";
 import { calculateOverviewStats } from "@web/lib/coe/calculations";
 import { loadCOEOverviewPageData } from "@web/lib/coe/page-data";
 import { createPageMetadata } from "@web/lib/metadata";
@@ -22,7 +21,6 @@ import { getLatestCoeResults } from "@web/queries/coe";
 import { formatPercent } from "@web/utils/charts";
 import { formatDateToMonthYear } from "@web/utils/format-date-to-month-year";
 import type { Metadata } from "next";
-import { cacheLife, cacheTag } from "next/cache";
 import Link from "next/link";
 import type { WebPage, WithContext } from "schema-dts";
 
@@ -52,10 +50,6 @@ export const generateMetadata = async (): Promise<Metadata> => {
 };
 
 const COEPricesPage = async () => {
-  "use cache";
-  cacheLife("max");
-  cacheTag(CACHE_TAG.COE);
-
   const { coeTrends, latestResults, allCoeResults, pqpRates, lastUpdated } =
     await loadCOEOverviewPageData();
 

--- a/apps/web/src/app/(dashboard)/coe/pqp/page.tsx
+++ b/apps/web/src/app/(dashboard)/coe/pqp/page.tsx
@@ -11,12 +11,10 @@ import { PageHeader } from "@web/components/page-header";
 import { StructuredData } from "@web/components/structured-data";
 import { UnreleasedFeature } from "@web/components/unreleased-feature";
 import { LAST_UPDATED_COE_KEY, SITE_URL } from "@web/config";
-import { CACHE_TAG } from "@web/lib/cache";
 import { createPageMetadata } from "@web/lib/metadata";
 import { getPQPOverview } from "@web/queries/coe";
 import type { Pqp } from "@web/types/coe";
 import type { Metadata } from "next";
-import { cacheLife, cacheTag } from "next/cache";
 import type { WebPage, WithContext } from "schema-dts";
 
 const title = "COE PQP Rates";
@@ -33,10 +31,6 @@ export const generateMetadata = (): Metadata => {
 };
 
 const PQPRatesPage = async () => {
-  "use cache";
-  cacheLife("max");
-  cacheTag(CACHE_TAG.COE);
-
   const overview = await getPQPOverview();
 
   const lastUpdated = await redis.get<number>(LAST_UPDATED_COE_KEY);

--- a/apps/web/src/app/api/revalidate/route.ts
+++ b/apps/web/src/app/api/revalidate/route.ts
@@ -1,6 +1,35 @@
 import { revalidatePath, revalidateTag } from "next/cache";
 import type { NextRequest } from "next/server";
 
+/**
+ * On-demand cache revalidation endpoint for granular cache tag invalidation.
+ *
+ * Supported cache tags:
+ *
+ * Cars:
+ * - cars:month:{month}     - Month-specific data (e.g., cars:month:2024-01)
+ * - cars:year:{year}       - Year-specific data (e.g., cars:year:2024)
+ * - cars:make:{make}       - Make-specific data (e.g., cars:make:toyota)
+ * - cars:fuel:{fuelType}   - Fuel type data (e.g., cars:fuel:electric)
+ * - cars:vehicle:{type}    - Vehicle type data (e.g., cars:vehicle:saloon)
+ * - cars:category:{cat}    - Category data (e.g., cars:category:saloon)
+ * - cars:makes             - All makes list
+ * - cars:months            - Available months list
+ * - cars:annual            - Yearly registration totals
+ *
+ * COE:
+ * - coe:results            - All COE results
+ * - coe:latest             - Latest COE results
+ * - coe:period:{period}    - Period-filtered data (e.g., coe:period:12m)
+ * - coe:category:{cat}     - Category data (e.g., coe:category:A)
+ * - coe:year:{year}        - Year-specific data (e.g., coe:year:2024)
+ * - coe:months             - Available COE months
+ * - coe:pqp                - PQP rates data
+ *
+ * Posts:
+ * - posts:list             - Blog post list
+ * - posts:slug:{slug}      - Individual post (e.g., posts:slug:jan-2024)
+ */
 export const POST = async (req: NextRequest) => {
   const token = req.headers.get("x-revalidate-token");
 

--- a/apps/web/src/app/blog/_actions/related.ts
+++ b/apps/web/src/app/blog/_actions/related.ts
@@ -58,6 +58,8 @@ const getTagSimilarPosts = async (
 const getPopularPosts = async (
   limit: number = 10,
 ): Promise<Array<{ postId: string; viewCount: number }>> => {
+  "use cache";
+
   try {
     // Get top posts by view count (highest to lowest) using zrange with REV
     const results = await redis.zrange<
@@ -85,6 +87,8 @@ const getPopularPosts = async (
 };
 
 export const getRelatedPosts = async (postId: string, limit: number = 3) => {
+  "use cache";
+
   try {
     const [tagRelated, popular] = await Promise.all([
       getTagSimilarPosts(postId, limit * 2),

--- a/apps/web/src/app/blog/_actions/views.ts
+++ b/apps/web/src/app/blog/_actions/views.ts
@@ -16,6 +16,8 @@ export const incrementPostView = async (postId: string): Promise<number> => {
 };
 
 export const getPostViewCount = async (postId: string): Promise<number> => {
+  "use cache";
+
   try {
     const count = await redis.get<string>(`blog:views:${postId}`);
     return Number.parseInt(count ?? "0", 10);

--- a/apps/web/src/app/blog/_components/view-counter.tsx
+++ b/apps/web/src/app/blog/_components/view-counter.tsx
@@ -1,11 +1,23 @@
+"use client";
+
 import { incrementPostView } from "@web/app/blog/_actions/views";
+import { useEffect, useEffectEvent, useState } from "react";
 
 interface ViewCounterProps {
   postId: string;
+  initialCount?: number;
 }
 
-export const ViewCounter = async ({ postId }: ViewCounterProps) => {
-  const views = await incrementPostView(postId);
+export const ViewCounter = ({ postId, initialCount = 0 }: ViewCounterProps) => {
+  const [views, setViews] = useState(initialCount);
+
+  const increasePostView = useEffectEvent(() => {
+    incrementPostView(postId).then(setViews);
+  });
+
+  useEffect(() => {
+    increasePostView();
+  }, []);
 
   return (
     <span className="text-muted-foreground">

--- a/apps/web/src/app/blog/page.tsx
+++ b/apps/web/src/app/blog/page.tsx
@@ -3,10 +3,8 @@ import { StructuredData } from "@web/components/structured-data";
 import { SubscribeForm } from "@web/components/subscribe-form";
 import Typography from "@web/components/typography";
 import { UnreleasedFeature } from "@web/components/unreleased-feature";
-import { CACHE_TAG } from "@web/lib/cache";
 import { getAllPosts } from "@web/lib/data/posts";
 import type { Metadata } from "next";
-import { cacheLife, cacheTag } from "next/cache";
 import type { Blog, WithContext } from "schema-dts";
 
 const title = "Blog";
@@ -40,10 +38,6 @@ export const metadata: Metadata = {
 };
 
 const Page = async () => {
-  "use cache";
-  cacheLife("max");
-  cacheTag(CACHE_TAG.POSTS);
-
   const posts = await getAllPosts();
 
   return (

--- a/apps/web/src/components/footer.tsx
+++ b/apps/web/src/components/footer.tsx
@@ -13,9 +13,9 @@ const NAV_ITEMS = [
   { href: "/faq", label: "FAQ" },
 ];
 
-export const Footer = async () => {
-  "use cache";
+const CURRENT_YEAR = new Date().getFullYear();
 
+export const Footer = () => {
   return (
     <footer className="border-divider border-t bg-content1">
       <div className="container mx-auto px-6 py-12">
@@ -70,8 +70,7 @@ export const Footer = async () => {
         <div className="flex flex-col items-center justify-between gap-4 md:flex-row md:gap-0">
           <div className="text-center text-default-600 md:text-left">
             <Typography.TextSm>
-              © {new Date().getFullYear()} SGCarsTrends. All rights reserved. •
-              v{version}
+              © {CURRENT_YEAR} SGCarsTrends. All rights reserved. • v{version}
             </Typography.TextSm>
             <Typography.TextSm>
               Data provided by{" "}

--- a/apps/web/src/lib/cache.ts
+++ b/apps/web/src/lib/cache.ts
@@ -1,4 +1,3 @@
 export const CACHE_TAG = {
-  CARS: "cars",
   COE: "coe",
 } as const;

--- a/apps/web/src/lib/cache.ts
+++ b/apps/web/src/lib/cache.ts
@@ -1,3 +1,4 @@
-export const CACHE_TAG = {
-  COE: "coe",
-} as const;
+// Cache tags are now defined inline in query functions
+// using granular patterns like: coe:months, cars:make:${make}
+// This file is kept for backwards compatibility with tests
+// TODO: Update tests to use inline tag assertions, then delete this file

--- a/apps/web/src/lib/cache.ts
+++ b/apps/web/src/lib/cache.ts
@@ -1,5 +1,4 @@
 export const CACHE_TAG = {
   CARS: "cars",
   COE: "coe",
-  POSTS: "posts",
 } as const;

--- a/apps/web/src/lib/cache.ts
+++ b/apps/web/src/lib/cache.ts
@@ -1,4 +1,0 @@
-// Cache tags are now defined inline in query functions
-// using granular patterns like: coe:months, cars:make:${make}
-// This file is kept for backwards compatibility with tests
-// TODO: Update tests to use inline tag assertions, then delete this file

--- a/apps/web/src/lib/data/months.ts
+++ b/apps/web/src/lib/data/months.ts
@@ -1,5 +1,4 @@
 import { cars, coe, db } from "@sgcarstrends/database";
-import { CACHE_TAG } from "@web/lib/cache";
 import { desc, max } from "drizzle-orm";
 import { cacheLife, cacheTag } from "next/cache";
 
@@ -48,7 +47,7 @@ export async function getCarsLatestMonth(): Promise<string | null> {
 export async function getCOELatestMonth(): Promise<string | null> {
   "use cache";
   cacheLife("max");
-  cacheTag(CACHE_TAG.COE);
+  cacheTag("coe:months");
 
   const [{ latestMonth }] = await db
     .select({ latestMonth: max(coe.month) })

--- a/apps/web/src/lib/data/months.ts
+++ b/apps/web/src/lib/data/months.ts
@@ -32,7 +32,7 @@ export const getLatestMonth = async (
 export async function getCarsLatestMonth(): Promise<string | null> {
   "use cache";
   cacheLife("max");
-  cacheTag(CACHE_TAG.CARS);
+  cacheTag("cars:months");
 
   const result = await db.query.cars.findFirst({
     columns: { month: true },

--- a/apps/web/src/lib/data/posts.ts
+++ b/apps/web/src/lib/data/posts.ts
@@ -1,12 +1,11 @@
 import { db, posts } from "@sgcarstrends/database";
-import { CACHE_TAG } from "@web/lib/cache";
 import { and, desc, eq, inArray, isNotNull } from "drizzle-orm";
 import { cacheLife, cacheTag } from "next/cache";
 
 export async function getAllPosts() {
   "use cache";
   cacheLife("max");
-  cacheTag(CACHE_TAG.POSTS);
+  cacheTag("posts:list");
 
   return db.query.posts.findMany({
     where: isNotNull(posts.publishedAt),
@@ -17,7 +16,7 @@ export async function getAllPosts() {
 export async function getPostBySlug(slug: string) {
   "use cache";
   cacheLife("max");
-  cacheTag(CACHE_TAG.POSTS);
+  cacheTag(`posts:slug:${slug}`);
 
   return db.query.posts.findFirst({
     where: and(eq(posts.slug, slug), isNotNull(posts.publishedAt)),
@@ -27,7 +26,6 @@ export async function getPostBySlug(slug: string) {
 export async function getPostsByIds(postIds: string[]) {
   "use cache";
   cacheLife("max");
-  cacheTag(CACHE_TAG.POSTS);
 
   if (postIds.length === 0) {
     return [];

--- a/apps/web/src/lib/data/posts.ts
+++ b/apps/web/src/lib/data/posts.ts
@@ -26,6 +26,7 @@ export async function getPostBySlug(slug: string) {
 export async function getPostsByIds(postIds: string[]) {
   "use cache";
   cacheLife("max");
+  cacheTag("posts:list");
 
   if (postIds.length === 0) {
     return [];

--- a/apps/web/src/queries/__tests__/filter-options.test.ts
+++ b/apps/web/src/queries/__tests__/filter-options.test.ts
@@ -1,4 +1,3 @@
-import { CACHE_TAG } from "@web/lib/cache";
 import {
   getCarsMonths,
   getDistinctFuelTypes,
@@ -71,6 +70,6 @@ describe("car filter option queries", () => {
 
     expect(result).toEqual([{ month: "2024-06" }, { month: "2024-05" }]);
     expect(cacheLifeMock).toHaveBeenCalledWith("max");
-    expect(cacheTagMock).toHaveBeenCalledWith(CACHE_TAG.CARS);
+    expect(cacheTagMock).toHaveBeenCalledWith("cars:months");
   });
 });

--- a/apps/web/src/queries/__tests__/makes.test.ts
+++ b/apps/web/src/queries/__tests__/makes.test.ts
@@ -1,4 +1,3 @@
-import { CACHE_TAG } from "@web/lib/cache";
 import { describe, expect, it, vi } from "vitest";
 import { getPopularMakes } from "../cars/makes/current-year-popular-makes";
 import {
@@ -139,7 +138,7 @@ describe("popular makes queries", () => {
 
     expect(result).toEqual(["Tesla", "BMW"]);
     expect(cacheLifeMock).toHaveBeenCalledWith("max");
-    expect(cacheTagMock).toHaveBeenCalledWith(CACHE_TAG.CARS);
+    expect(cacheTagMock).toHaveBeenCalledWith("cars:year:2023");
   });
 
   it("loads current year when year argument is omitted", async () => {
@@ -148,7 +147,8 @@ describe("popular makes queries", () => {
     const result = await getPopularMakes();
 
     expect(result).toEqual(["Honda"]);
-    expect(cacheTagMock).toHaveBeenCalledWith(CACHE_TAG.CARS);
+    // cacheTag is only called when year is explicitly provided
+    expect(cacheTagMock).not.toHaveBeenCalled();
   });
 
   it("falls back to calendar year when latest month query returns no results", async () => {

--- a/apps/web/src/queries/__tests__/market-insights.test.ts
+++ b/apps/web/src/queries/__tests__/market-insights.test.ts
@@ -1,4 +1,3 @@
-import { CACHE_TAG } from "@web/lib/cache";
 import { describe, expect, it, vi } from "vitest";
 import {
   cacheLifeMock,
@@ -36,7 +35,7 @@ describe("car market insight queries", () => {
       topVehicleType: { name: "SUV", total: 40 },
     });
     expect(cacheLifeMock).toHaveBeenCalledWith("max");
-    expect(cacheTagMock).toHaveBeenCalledWith(CACHE_TAG.CARS);
+    expect(cacheTagMock).toHaveBeenCalledWith("cars:month:2024-04");
   });
 
   it("falls back to placeholder entries when no types exist", async () => {
@@ -80,7 +79,7 @@ describe("car market insight queries", () => {
         makes: [{ make: "Toyota", count: 20 }],
       },
     ]);
-    expect(cacheTagMock).toHaveBeenCalledWith(CACHE_TAG.CARS);
+    expect(cacheTagMock).toHaveBeenCalledWith("cars:month:2024-06");
   });
 
   it("computes market share breakdowns from cached data", async () => {

--- a/apps/web/src/queries/__tests__/monthly-registrations.test.ts
+++ b/apps/web/src/queries/__tests__/monthly-registrations.test.ts
@@ -1,4 +1,3 @@
-import { CACHE_TAG } from "@web/lib/cache";
 import { describe, expect, it } from "vitest";
 import { getCarsComparison, getCarsData } from "../cars/monthly-registrations";
 import {
@@ -35,7 +34,7 @@ describe("monthly registration queries", () => {
       vehicleType: [{ name: "SUV", count: 5 }],
     });
     expect(cacheLifeMock).toHaveBeenCalledWith("max");
-    expect(cacheTagMock).toHaveBeenCalledWith(CACHE_TAG.CARS);
+    expect(cacheTagMock).toHaveBeenCalledWith("cars:month:2024-06");
   });
 
   it("provides comparisons for previous month and year", async () => {
@@ -71,6 +70,6 @@ describe("monthly registration queries", () => {
       fuelType: [],
       vehicleType: [],
     });
-    expect(cacheTagMock).toHaveBeenCalledWith(CACHE_TAG.CARS);
+    expect(cacheTagMock).toHaveBeenCalledWith("cars:month:2024-06");
   });
 });

--- a/apps/web/src/queries/__tests__/yearly-statistics.test.ts
+++ b/apps/web/src/queries/__tests__/yearly-statistics.test.ts
@@ -1,4 +1,3 @@
-import { CACHE_TAG } from "@web/lib/cache";
 import { describe, expect, it } from "vitest";
 import {
   getTopMakesByYear,
@@ -23,7 +22,7 @@ describe("yearly statistics queries", () => {
 
     expect(result).toEqual([{ year: 2022, total: 123 }]);
     expect(cacheLifeMock).toHaveBeenCalledWith("max");
-    expect(cacheTagMock).toHaveBeenCalledWith(CACHE_TAG.CARS);
+    expect(cacheTagMock).toHaveBeenCalledWith("cars:annual");
   });
 
   it("returns top makes for an explicit year", async () => {
@@ -32,7 +31,7 @@ describe("yearly statistics queries", () => {
     const result = await getTopMakesByYear(2024, 1);
 
     expect(result).toEqual([{ make: "Tesla", value: 50 }]);
-    expect(cacheTagMock).toHaveBeenCalledWith(CACHE_TAG.CARS);
+    expect(cacheTagMock).toHaveBeenCalledWith("cars:year:2024");
   });
 
   it("derives latest year when no year is supplied", async () => {

--- a/apps/web/src/queries/cars/filter-options.ts
+++ b/apps/web/src/queries/cars/filter-options.ts
@@ -1,12 +1,11 @@
 import { cars, db } from "@sgcarstrends/database";
-import { CACHE_TAG } from "@web/lib/cache";
 import { and, desc, eq } from "drizzle-orm";
 import { cacheLife, cacheTag } from "next/cache";
 
 export const getDistinctMakes = async () => {
   "use cache";
   cacheLife("max");
-  cacheTag(CACHE_TAG.CARS);
+  cacheTag("cars:makes");
 
   return db.selectDistinct({ make: cars.make }).from(cars).orderBy(cars.make);
 };
@@ -16,7 +15,9 @@ export const getDistinctFuelTypes = async (
 ): Promise<{ fuelType: string }[]> => {
   "use cache";
   cacheLife("max");
-  cacheTag(CACHE_TAG.CARS);
+  if (month) {
+    cacheTag(`cars:month:${month}`);
+  }
 
   const filters = [];
 
@@ -36,7 +37,9 @@ export const getDistinctVehicleTypes = async (
 ): Promise<{ vehicleType: string }[]> => {
   "use cache";
   cacheLife("max");
-  cacheTag(CACHE_TAG.CARS);
+  if (month) {
+    cacheTag(`cars:month:${month}`);
+  }
 
   const filters = [];
 
@@ -54,7 +57,7 @@ export const getDistinctVehicleTypes = async (
 export const getCarsMonths = async (): Promise<{ month: string }[]> => {
   "use cache";
   cacheLife("max");
-  cacheTag(CACHE_TAG.CARS);
+  cacheTag("cars:months");
 
   return db
     .selectDistinct({ month: cars.month })

--- a/apps/web/src/queries/cars/makes/coe-comparison.ts
+++ b/apps/web/src/queries/cars/makes/coe-comparison.ts
@@ -1,5 +1,4 @@
 import { cars, coe, db } from "@sgcarstrends/database";
-import { CACHE_TAG } from "@web/lib/cache";
 import { subMonths } from "date-fns";
 import { and, asc, avg, gte, ilike, inArray, lte, sql } from "drizzle-orm";
 import { cacheLife, cacheTag } from "next/cache";
@@ -28,8 +27,7 @@ export const getMakeCoeComparison = async (
   cacheLife("max");
 
   const { startMonth, endMonth } = getDateRange24Months();
-  cacheTag(CACHE_TAG.CARS);
-  cacheTag(CACHE_TAG.COE);
+  cacheTag(`cars:make:${make}`);
 
   const pattern = make.replaceAll("-", "%");
 

--- a/apps/web/src/queries/cars/makes/current-year-popular-makes.ts
+++ b/apps/web/src/queries/cars/makes/current-year-popular-makes.ts
@@ -1,5 +1,4 @@
 import { cars, db } from "@sgcarstrends/database";
-import { CACHE_TAG } from "@web/lib/cache";
 import { and, desc, gt, ilike, max, sql } from "drizzle-orm";
 import { cacheLife, cacheTag } from "next/cache";
 
@@ -49,7 +48,9 @@ const getPopularMakesByYearData = async (year: string, limit: number = 8) => {
 export const getPopularMakes = async (year?: string) => {
   "use cache";
   cacheLife("max");
-  cacheTag(CACHE_TAG.CARS);
+  if (year) {
+    cacheTag(`cars:year:${year}`);
+  }
 
   const targetYear = year ?? (await getLatestYear());
   return getPopularMakesByYearData(targetYear, 8);

--- a/apps/web/src/queries/cars/makes/entity-breakdowns.ts
+++ b/apps/web/src/queries/cars/makes/entity-breakdowns.ts
@@ -1,5 +1,4 @@
 import { cars, db, type SelectCar } from "@sgcarstrends/database";
-import { CACHE_TAG } from "@web/lib/cache";
 import { and, desc, eq, ilike, sql } from "drizzle-orm";
 import { cacheLife, cacheTag } from "next/cache";
 
@@ -34,7 +33,10 @@ export const getMakeDetails = async (
 ): Promise<MakeDetails> => {
   "use cache";
   cacheLife("max");
-  cacheTag(CACHE_TAG.CARS);
+  cacheTag(`cars:make:${make}`);
+  if (month) {
+    cacheTag(`cars:month:${month}`);
+  }
 
   const pattern = make.replaceAll("-", "%");
   const whereConditions = [ilike(cars.make, pattern)];
@@ -75,7 +77,10 @@ export const getFuelTypeData = async (
 ): Promise<FuelTypeData> => {
   "use cache";
   cacheLife("max");
-  cacheTag(CACHE_TAG.CARS);
+  cacheTag(`cars:fuel:${fuelType}`);
+  if (month) {
+    cacheTag(`cars:month:${month}`);
+  }
 
   const pattern = fuelType.replaceAll("-", "%");
   const whereConditions = [ilike(cars.fuelType, pattern)];
@@ -121,7 +126,10 @@ export const getVehicleTypeData = async (
 ): Promise<VehicleTypeData> => {
   "use cache";
   cacheLife("max");
-  cacheTag(CACHE_TAG.CARS);
+  cacheTag(`cars:vehicle:${vehicleType}`);
+  if (month) {
+    cacheTag(`cars:month:${month}`);
+  }
 
   const pattern = vehicleType.replaceAll("-", "%");
   const whereConditions = [ilike(cars.vehicleType, pattern)];

--- a/apps/web/src/queries/cars/makes/entity-checks.ts
+++ b/apps/web/src/queries/cars/makes/entity-checks.ts
@@ -1,5 +1,4 @@
 import { cars, db } from "@sgcarstrends/database";
-import { CACHE_TAG } from "@web/lib/cache";
 import { ilike } from "drizzle-orm";
 import { cacheLife, cacheTag } from "next/cache";
 
@@ -10,7 +9,7 @@ export const checkMakeIfExist = async (
 ): Promise<{ make: string } | undefined> => {
   "use cache";
   cacheLife("max");
-  cacheTag(CACHE_TAG.CARS);
+  cacheTag(`cars:make:${make}`);
 
   const result = await db.query.cars.findFirst({
     where: ilike(cars.make, normalisePattern(make)),
@@ -25,7 +24,7 @@ export const checkFuelTypeIfExist = async (
 ): Promise<{ fuelType: string } | undefined> => {
   "use cache";
   cacheLife("max");
-  cacheTag(CACHE_TAG.CARS);
+  cacheTag(`cars:fuel:${fuelType}`);
 
   const result = await db.query.cars.findFirst({
     where: ilike(cars.fuelType, normalisePattern(fuelType)),
@@ -40,7 +39,7 @@ export const checkVehicleTypeIfExist = async (
 ): Promise<{ vehicleType: string } | undefined> => {
   "use cache";
   cacheLife("max");
-  cacheTag(CACHE_TAG.CARS);
+  cacheTag(`cars:vehicle:${vehicleType}`);
 
   const result = await db.query.cars.findFirst({
     where: ilike(cars.vehicleType, normalisePattern(vehicleType)),

--- a/apps/web/src/queries/cars/market-insights.ts
+++ b/apps/web/src/queries/cars/market-insights.ts
@@ -1,5 +1,4 @@
 import { cars, db } from "@sgcarstrends/database";
-import { CACHE_TAG } from "@web/lib/cache";
 import { getCarsData } from "@web/queries";
 import type { FuelType, TopType } from "@web/types/cars";
 import { and, desc, eq, gt, sql } from "drizzle-orm";
@@ -55,7 +54,7 @@ interface TopMake {
 export const getTopTypes = async (month: string): Promise<TopType> => {
   "use cache";
   cacheLife("max");
-  cacheTag(CACHE_TAG.CARS);
+  cacheTag(`cars:month:${month}`);
 
   const topFuelTypeQuery = db
     .select({
@@ -97,7 +96,7 @@ export const getTopTypes = async (month: string): Promise<TopType> => {
 export const getTopMakes = async (month: string): Promise<TopMake[]> => {
   "use cache";
   cacheLife("max");
-  cacheTag(CACHE_TAG.CARS);
+  cacheTag(`cars:month:${month}`);
 
   return db
     .select({
@@ -116,7 +115,7 @@ export const getTopMakesByFuelType = async (
 ): Promise<FuelType[]> => {
   "use cache";
   cacheLife("max");
-  cacheTag(CACHE_TAG.CARS);
+  cacheTag(`cars:month:${month}`);
 
   const fuelTypeResults = await db
     .select({
@@ -163,7 +162,7 @@ export const getCarMarketShareData = async (
 ): Promise<CarMarketShareResponse> => {
   "use cache";
   cacheLife("max");
-  cacheTag(CACHE_TAG.CARS);
+  cacheTag(`cars:month:${month}`, `cars:category:${category}`);
 
   const response = await getCarsData(month);
 
@@ -215,7 +214,7 @@ export const getCarTopPerformersData = async (
 ): Promise<CarTopPerformersData> => {
   "use cache";
   cacheLife("max");
-  cacheTag(CACHE_TAG.CARS);
+  cacheTag(`cars:month:${month}`);
 
   const [topTypes, topMakes] = await Promise.all([
     getTopTypes(month),

--- a/apps/web/src/queries/cars/monthly-registrations.ts
+++ b/apps/web/src/queries/cars/monthly-registrations.ts
@@ -1,5 +1,4 @@
 import { cars, db } from "@sgcarstrends/database";
-import { CACHE_TAG } from "@web/lib/cache";
 import type { Comparison, Registration } from "@web/types/cars";
 import { format, subMonths } from "date-fns";
 import { desc, eq, sql } from "drizzle-orm";
@@ -8,7 +7,7 @@ import { cacheLife, cacheTag } from "next/cache";
 export const getCarsData = async (month: string): Promise<Registration> => {
   "use cache";
   cacheLife("max");
-  cacheTag(CACHE_TAG.CARS);
+  cacheTag(`cars:month:${month}`);
 
   const fuelTypeQuery = db
     .select({
@@ -56,7 +55,7 @@ export const getCarsData = async (month: string): Promise<Registration> => {
 export const getCarsComparison = async (month: string): Promise<Comparison> => {
   "use cache";
   cacheLife("max");
-  cacheTag(CACHE_TAG.CARS);
+  cacheTag(`cars:month:${month}`);
 
   const currentDate = new Date(`${month}-01`);
   const previousMonthDate = subMonths(currentDate, 1);

--- a/apps/web/src/queries/cars/yearly-statistics.ts
+++ b/apps/web/src/queries/cars/yearly-statistics.ts
@@ -1,5 +1,4 @@
 import { cars, db } from "@sgcarstrends/database";
-import { CACHE_TAG } from "@web/lib/cache";
 import { and, desc, eq, gt, sql } from "drizzle-orm";
 import { cacheLife, cacheTag } from "next/cache";
 
@@ -11,7 +10,7 @@ const yearExpr = sql`extract(year from to_date(${cars.month}, 'YYYY-MM'))`;
 export const getYearlyRegistrations = async () => {
   "use cache";
   cacheLife("max");
-  cacheTag(CACHE_TAG.CARS);
+  cacheTag("cars:annual");
 
   const results = await db
     .select({
@@ -35,7 +34,9 @@ export const getYearlyRegistrations = async () => {
 export const getTopMakesByYear = async (year?: number, limit = 8) => {
   "use cache";
   cacheLife("max");
-  cacheTag(CACHE_TAG.CARS);
+  if (year) {
+    cacheTag(`cars:year:${year}`);
+  }
 
   let targetYear = year;
 

--- a/apps/web/src/queries/coe/available-months.ts
+++ b/apps/web/src/queries/coe/available-months.ts
@@ -1,12 +1,11 @@
 import { coe, db } from "@sgcarstrends/database";
-import { CACHE_TAG } from "@web/lib/cache";
 import { desc } from "drizzle-orm";
 import { cacheLife, cacheTag } from "next/cache";
 
 export const getCoeMonths = async (): Promise<{ month: string }[]> => {
   "use cache";
   cacheLife("max");
-  cacheTag(CACHE_TAG.COE);
+  cacheTag("coe:months");
 
   const results = await db
     .selectDistinct({ month: coe.month })

--- a/apps/web/src/queries/coe/latest-results.ts
+++ b/apps/web/src/queries/coe/latest-results.ts
@@ -1,5 +1,4 @@
 import { coe, db } from "@sgcarstrends/database";
-import { CACHE_TAG } from "@web/lib/cache";
 import type { COEResult } from "@web/types";
 import { and, asc, desc, eq, inArray, max } from "drizzle-orm";
 import { cacheLife, cacheTag } from "next/cache";
@@ -7,7 +6,7 @@ import { cacheLife, cacheTag } from "next/cache";
 export const getLatestCoeResults = async (): Promise<COEResult[]> => {
   "use cache";
   cacheLife("max");
-  cacheTag(CACHE_TAG.COE);
+  cacheTag("coe:latest");
 
   const [{ latestMonth }] = await db
     .select({ latestMonth: max(coe.month) })

--- a/apps/web/src/queries/coe/pqp/overview.ts
+++ b/apps/web/src/queries/coe/pqp/overview.ts
@@ -1,5 +1,4 @@
 import { coe, db, pqp } from "@sgcarstrends/database";
-import { CACHE_TAG } from "@web/lib/cache";
 import type { Pqp } from "@web/types/coe";
 import { and, desc, eq, inArray, isNotNull } from "drizzle-orm";
 import { cacheLife, cacheTag } from "next/cache";
@@ -37,7 +36,7 @@ const toNumber = (value: number | string | null | undefined): number => {
 export const getPQPOverview = async (): Promise<Pqp.Overview> => {
   "use cache";
   cacheLife("max");
-  cacheTag(CACHE_TAG.COE);
+  cacheTag("coe:pqp");
 
   const recentMonthsRows = await db
     .selectDistinct({ month: pqp.month })

--- a/apps/web/src/queries/coe/pqp/rates.ts
+++ b/apps/web/src/queries/coe/pqp/rates.ts
@@ -1,5 +1,4 @@
 import { db, pqp } from "@sgcarstrends/database";
-import { CACHE_TAG } from "@web/lib/cache";
 import type { Pqp } from "@web/types/coe";
 import { asc, desc } from "drizzle-orm";
 import { cacheLife, cacheTag } from "next/cache";
@@ -7,7 +6,7 @@ import { cacheLife, cacheTag } from "next/cache";
 export const getPqpRates = async (): Promise<Record<string, Pqp.Rates>> => {
   "use cache";
   cacheLife("max");
-  cacheTag(CACHE_TAG.COE);
+  cacheTag("coe:pqp");
 
   const results = await db
     .select()

--- a/apps/web/src/queries/coe/trends.ts
+++ b/apps/web/src/queries/coe/trends.ts
@@ -1,5 +1,4 @@
 import { coe, db, type SelectCOE } from "@sgcarstrends/database";
-import { CACHE_TAG } from "@web/lib/cache";
 import type { COECategory } from "@web/types";
 import { and, asc, desc, eq, gte, lte } from "drizzle-orm";
 import { cacheLife, cacheTag } from "next/cache";
@@ -79,9 +78,12 @@ export const getCoeCategoryTrends = async (
 ): Promise<CoeMonthlyPremium[]> => {
   "use cache";
   cacheLife("max");
+  cacheTag(`coe:category:${category}`);
+  if (year) {
+    cacheTag(`coe:year:${year}`);
+  }
 
   const { startMonth, endMonth } = getDateRange(year);
-  cacheTag(CACHE_TAG.COE);
 
   const results = await fetchCoeResults(startMonth, endMonth, category);
   const monthlyTrends = new Map<string, CoeMonthlyPremium>();
@@ -98,9 +100,11 @@ export const getAllCoeCategoryTrends = async (
 ): Promise<Record<COECategory, CoeMonthlyPremium[]>> => {
   "use cache";
   cacheLife("max");
+  if (year) {
+    cacheTag(`coe:year:${year}`);
+  }
 
   const { startMonth, endMonth } = getDateRange(year);
-  cacheTag(CACHE_TAG.COE);
 
   const results = await fetchCoeResults(startMonth, endMonth);
 


### PR DESCRIPTION
## Summary
- Replace generic cache tags with granular tags (`cars:month:*`, `coe:year:*`, etc.) for precise cache invalidation
- Update API workflows to use specific cache tags when revalidating web app caches