### PR TITLE
Add COE premium range display

### DIFF
--- a/apps/web/src/app/(dashboard)/coe/_components/premium-range-card.tsx
+++ b/apps/web/src/app/(dashboard)/coe/_components/premium-range-card.tsx
@@ -1,0 +1,229 @@
+import { Card, CardBody, CardHeader } from "@heroui/card";
+import { Chip } from "@heroui/chip";
+import Typography from "@web/components/typography";
+import {
+  COE_CHART_COLOURS,
+  type PremiumRangeStats,
+} from "@web/lib/coe/calculations";
+import { formatDateToMonthYear } from "@web/utils/format-date-to-month-year";
+
+interface PremiumRangeCardProps {
+  stats: PremiumRangeStats[];
+}
+
+const CATEGORY_COLOR_MAP: Record<string, string> = {
+  "Category A": COE_CHART_COLOURS[0],
+  "Category B": COE_CHART_COLOURS[1],
+  "Category C": COE_CHART_COLOURS[2],
+  "Category D": COE_CHART_COLOURS[3],
+  "Category E": COE_CHART_COLOURS[4],
+};
+
+const formatCurrency = (value: number) => `S$${value.toLocaleString("en-SG")}`;
+
+interface RangeBarProps {
+  lowest: number;
+  highest: number;
+  globalMin: number;
+  globalMax: number;
+  accentColor: string;
+}
+
+const RangeBar = ({
+  lowest,
+  highest,
+  globalMin,
+  globalMax,
+  accentColor,
+}: RangeBarProps) => {
+  const range = globalMax - globalMin;
+  const leftPercent = range > 0 ? ((lowest - globalMin) / range) * 100 : 0;
+  const widthPercent = range > 0 ? ((highest - lowest) / range) * 100 : 100;
+
+  return (
+    <div className="relative h-2 w-full rounded-full bg-default-100">
+      <div
+        className="absolute h-full rounded-full transition-all duration-500 ease-out"
+        style={{
+          left: `${leftPercent}%`,
+          width: `${Math.max(widthPercent, 2)}%`,
+          background: `linear-gradient(90deg, ${accentColor}40, ${accentColor})`,
+          boxShadow: `0 0 8px ${accentColor}40`,
+        }}
+      />
+      {/* Low marker */}
+      <div
+        className="-translate-y-1/2 absolute top-1/2 h-3 w-1 rounded-full bg-success-500"
+        style={{ left: `${leftPercent}%` }}
+        title={`Low: ${formatCurrency(lowest)}`}
+      />
+      {/* High marker */}
+      <div
+        className="-translate-y-1/2 absolute top-1/2 h-3 w-1 rounded-full bg-danger-500"
+        style={{ left: `${leftPercent + widthPercent}%` }}
+        title={`High: ${formatCurrency(highest)}`}
+      />
+    </div>
+  );
+};
+
+interface RangeSectionProps {
+  label: string;
+  highest: number;
+  lowest: number;
+  highestDate?: string;
+  lowestDate?: string;
+  globalMin: number;
+  globalMax: number;
+  accentColor: string;
+}
+
+const RangeSection = ({
+  label,
+  highest,
+  lowest,
+  highestDate,
+  lowestDate,
+  globalMin,
+  globalMax,
+  accentColor,
+}: RangeSectionProps) => {
+  const spread = highest - lowest;
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex items-center justify-between">
+        <Chip size="sm" variant="flat" className="font-medium">
+          {label}
+        </Chip>
+        <span className="text-default-400 text-xs">
+          Spread: {formatCurrency(spread)}
+        </span>
+      </div>
+
+      <RangeBar
+        lowest={lowest}
+        highest={highest}
+        globalMin={globalMin}
+        globalMax={globalMax}
+        accentColor={accentColor}
+      />
+
+      <div className="grid grid-cols-2 gap-4">
+        {/* Low value */}
+        <div className="flex flex-col gap-0.5">
+          <div className="flex items-center gap-1.5">
+            <div className="h-2 w-2 rounded-full bg-success-500" />
+            <span className="text-default-500 text-xs uppercase tracking-wider">
+              Low
+            </span>
+          </div>
+          <span className="font-semibold text-foreground text-lg tabular-nums">
+            {formatCurrency(lowest)}
+          </span>
+          {lowestDate && (
+            <Typography.Caption>
+              {formatDateToMonthYear(lowestDate)}
+            </Typography.Caption>
+          )}
+        </div>
+
+        {/* High value */}
+        <div className="flex flex-col gap-0.5 text-right">
+          <div className="flex items-center justify-end gap-1.5">
+            <span className="text-default-500 text-xs uppercase tracking-wider">
+              High
+            </span>
+            <div className="h-2 w-2 rounded-full bg-danger-500" />
+          </div>
+          <span className="font-semibold text-foreground text-lg tabular-nums">
+            {formatCurrency(highest)}
+          </span>
+          {highestDate && (
+            <Typography.Caption>
+              {formatDateToMonthYear(highestDate)}
+            </Typography.Caption>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export const PremiumRangeCard = ({ stats }: PremiumRangeCardProps) => {
+  // Calculate global min/max for consistent range bar scaling
+  const allPremiums = stats.flatMap((s) => [
+    s.allTime.lowest,
+    s.allTime.highest,
+    ...(s.ytd ? [s.ytd.lowest, s.ytd.highest] : []),
+  ]);
+  const globalMin = Math.min(...allPremiums);
+  const globalMax = Math.max(...allPremiums);
+
+  return (
+    <>
+      {stats.map((stat) => {
+        const accentColor = CATEGORY_COLOR_MAP[stat.category] || "#6366f1";
+        const currentYear = new Date().getFullYear();
+
+        return (
+          <Card
+            key={stat.category}
+            className="group relative overflow-hidden transition-shadow duration-300 hover:shadow-lg"
+          >
+            {/* Accent bar at top */}
+            <div
+              className="absolute top-0 right-0 left-0 h-1"
+              style={{ backgroundColor: accentColor }}
+            />
+
+            <CardHeader className="flex flex-col items-start gap-1 pt-4">
+              <Typography.H4>{stat.category}</Typography.H4>
+              <Typography.Caption>Premium range analysis</Typography.Caption>
+            </CardHeader>
+
+            <CardBody className="flex flex-col gap-6 pt-0">
+              {/* YTD Range */}
+              {stat.ytd ? (
+                <RangeSection
+                  label={`${currentYear} YTD`}
+                  highest={stat.ytd.highest}
+                  lowest={stat.ytd.lowest}
+                  highestDate={stat.ytd.highestDate}
+                  lowestDate={stat.ytd.lowestDate}
+                  globalMin={globalMin}
+                  globalMax={globalMax}
+                  accentColor={accentColor}
+                />
+              ) : (
+                <div className="flex flex-col gap-2">
+                  <Chip size="sm" variant="flat" className="font-medium">
+                    {currentYear} YTD
+                  </Chip>
+                  <Typography.TextSm className="text-default-400">
+                    No data available for {currentYear}
+                  </Typography.TextSm>
+                </div>
+              )}
+
+              {/* Divider */}
+              <div className="h-px bg-divider" />
+
+              {/* All-time Range */}
+              <RangeSection
+                label="All-time"
+                highest={stat.allTime.highest}
+                lowest={stat.allTime.lowest}
+                highestDate={stat.allTime.highestDate}
+                lowestDate={stat.allTime.lowestDate}
+                globalMin={globalMin}
+                globalMax={globalMax}
+                accentColor={accentColor}
+              />
+            </CardBody>
+          </Card>
+        );
+      })}
+    </>
+  );
+};

--- a/apps/web/src/app/(dashboard)/coe/page.tsx
+++ b/apps/web/src/app/(dashboard)/coe/page.tsx
@@ -1,13 +1,14 @@
 import { Button } from "@heroui/button";
 import { Card, CardBody, CardFooter, CardHeader } from "@heroui/card";
 import { Progress } from "@heroui/progress";
+import { PremiumRangeCard } from "@web/app/(dashboard)/coe/_components/premium-range-card";
 import { AnimatedNumber } from "@web/components/animated-number";
 import { LatestCoePremium } from "@web/components/coe/latest-coe-premium";
 import { PageHeader } from "@web/components/page-header";
 import { StructuredData } from "@web/components/structured-data";
 import Typography from "@web/components/typography";
 import { SITE_TITLE, SITE_URL } from "@web/config";
-import { calculateOverviewStats } from "@web/lib/coe/calculations";
+import { calculatePremiumRangeStats } from "@web/lib/coe/calculations";
 import { loadCOEOverviewPageData } from "@web/lib/coe/page-data";
 import { createPageMetadata } from "@web/lib/metadata";
 import { getLatestCoeResults } from "@web/queries/coe";
@@ -59,8 +60,17 @@ const COEPricesPage = async () => {
     },
   };
 
-  const categories = ["Category A", "Category B", "Category E"];
-  const summaryStats = calculateOverviewStats(allCoeResults, categories);
+  const allCategories = [
+    "Category A",
+    "Category B",
+    "Category C",
+    "Category D",
+    "Category E",
+  ];
+  const premiumRangeStats = calculatePremiumRangeStats(
+    allCoeResults,
+    allCategories,
+  );
 
   // Get latest PQP rates
   const latestPqpData = Object.entries(pqpRates)[0];
@@ -110,46 +120,12 @@ const COEPricesPage = async () => {
               </div>
             </CardBody>
           </Card>
-          <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
-            {summaryStats.map((stat) => (
-              <Card key={stat?.category}>
-                <CardHeader className="flex flex-col items-start gap-2">
-                  <h3 className="font-medium text-foreground text-xl">
-                    {stat?.category}
-                  </h3>
-                </CardHeader>
-                <CardBody>
-                  <div className="flex flex-col gap-4">
-                    <div className="grid grid-cols-1 gap-2 text-muted-foreground">
-                      <div>
-                        <div className="text-red-600">
-                          Record High:{" "}
-                          <span className="font-semibold">
-                            ${stat?.highest.toLocaleString()}
-                          </span>
-                        </div>
-                        <Typography.Caption>
-                          {stat?.highestRecord.date &&
-                            formatDateToMonthYear(stat.highestRecord.date)}
-                        </Typography.Caption>
-                      </div>
-                      <div>
-                        <div className="text-green-600">
-                          Record Low:{" "}
-                          <span className="font-semibold">
-                            ${stat?.lowest.toLocaleString()}
-                          </span>
-                        </div>
-                        <Typography.Caption>
-                          {stat?.lowestRecord.date &&
-                            formatDateToMonthYear(stat.lowestRecord.date)}
-                        </Typography.Caption>
-                      </div>
-                    </div>
-                  </div>
-                </CardBody>
-              </Card>
-            ))}
+        </div>
+
+        <div className="flex flex-col gap-4">
+          <Typography.H2>Premium Ranges</Typography.H2>
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-5">
+            <PremiumRangeCard stats={premiumRangeStats} />
           </div>
         </div>
 
@@ -166,7 +142,14 @@ const COEPricesPage = async () => {
           <CardBody>
             <div className="flex flex-col gap-4">
               {Object.entries(latestPqpRates)
-                .filter(([key]) => categories.includes(key))
+                .filter(([key]) =>
+                  [
+                    "Category A",
+                    "Category B",
+                    "Category C",
+                    "Category D",
+                  ].includes(key),
+                )
                 .map(([category, rate]) => (
                   <div
                     key={category}


### PR DESCRIPTION
## Summary
- Add YTD and all-time premium range display for all 5 COE categories on overview page
- New `PremiumRangeCard` component with visual range bars, min/max values and dates

Closes #448