### PR TITLE
Add share buttons to all pages

### DIFF
--- a/apps/web/CLAUDE.md
+++ b/apps/web/CLAUDE.md
@@ -355,6 +355,13 @@ See [Typography System](#typography-system) section below.
 
 **Layout**: Shared layout components (Header, Footer) with responsive design and blog navigation.
 
+**Social Sharing**: `ShareButtons` component (`src/components/share-buttons.tsx`) provides social media sharing across all pages:
+
+- Responsive design: native Web Share API on mobile, individual buttons (X, LinkedIn, copy link) on desktop
+- CSS-only responsive behaviour using Tailwind classes (`flex md:hidden` / `hidden md:flex`)
+- Integrated into all statistics pages, blog posts, and dashboard views
+- Share utilities in `src/utils/share.ts` for URL generation and clipboard operations
+
 ### Typography System
 
 A modern, semantic typography system for consistent visual hierarchy across the application.

--- a/apps/web/src/app/(dashboard)/(home)/annual/page.tsx
+++ b/apps/web/src/app/(dashboard)/(home)/annual/page.tsx
@@ -1,4 +1,5 @@
 import { AnnualRegistrationsChart } from "@web/app/(dashboard)/(home)/annual/_components/annual-registrations-chart";
+import { ShareButtons } from "@web/components/share-buttons";
 import { StructuredData } from "@web/components/structured-data";
 import Typography from "@web/components/typography";
 import { SITE_TITLE, SITE_URL } from "@web/config";
@@ -45,8 +46,14 @@ const AnnualPage = async () => {
     <>
       <StructuredData data={structuredData} />
       <section className="flex flex-col gap-8">
-        <div className="flex flex-col">
-          <Typography.H1>Annual Registrations</Typography.H1>
+        <div className="flex flex-col gap-2">
+          <div className="flex items-center justify-between">
+            <Typography.H1>Annual Registrations</Typography.H1>
+            <ShareButtons
+              url={`${SITE_URL}/annual`}
+              title={`Annual Car Registrations - ${SITE_TITLE}`}
+            />
+          </div>
           <Typography.TextLg className="text-default-500">
             Total new car registrations in Singapore by year
           </Typography.TextLg>

--- a/apps/web/src/app/(dashboard)/cars/[category]/[type]/page.tsx
+++ b/apps/web/src/app/(dashboard)/cars/[category]/[type]/page.tsx
@@ -5,6 +5,7 @@ import { CarOverviewTrends } from "@web/app/(dashboard)/cars/_components/overvie
 import { loadSearchParams } from "@web/app/(dashboard)/cars/[category]/[type]/search-params";
 import { AnimatedNumber } from "@web/components/animated-number";
 import { PageHeader } from "@web/components/page-header";
+import { ShareButtons } from "@web/components/share-buttons";
 import { StructuredData } from "@web/components/structured-data";
 import Typography from "@web/components/typography";
 import { SITE_TITLE, SITE_URL } from "@web/config";
@@ -166,7 +167,12 @@ const TypePageContent = async ({
           lastUpdated={lastUpdated}
           months={months}
           showMonthSelector={true}
-        />
+        >
+          <ShareButtons
+            url={`${SITE_URL}/cars/${category}/${type}?month=${month}`}
+            title={`${category === "vehicle-types" ? formatVehicleTypeSlug(type) : type} - ${formattedMonth} - ${SITE_TITLE}`}
+          />
+        </PageHeader>
         <div className="flex flex-col gap-4">
           <div className="grid grid-cols-1 gap-4 lg:grid-cols-3">
             <Card>

--- a/apps/web/src/app/(dashboard)/cars/[category]/page.tsx
+++ b/apps/web/src/app/(dashboard)/cars/[category]/page.tsx
@@ -1,5 +1,6 @@
 import { loadSearchParams } from "@web/app/(dashboard)/cars/search-params";
 import { PageHeader } from "@web/components/page-header";
+import { ShareButtons } from "@web/components/share-buttons";
 import { StructuredData } from "@web/components/structured-data";
 import Typography from "@web/components/typography";
 import { SITE_TITLE, SITE_URL } from "@web/config";
@@ -133,7 +134,12 @@ const CategoryPageContent = async ({
           lastUpdated={lastUpdated}
           months={months}
           showMonthSelector={true}
-        />
+        >
+          <ShareButtons
+            url={`${SITE_URL}${config.urlPath}?month=${month}`}
+            title={`${formattedMonth} ${config.title} - ${SITE_TITLE}`}
+          />
+        </PageHeader>
 
         {categoryData && categoryData.length > 0 ? (
           <CategoryTypesTabsView

--- a/apps/web/src/app/(dashboard)/cars/_components/makes/make-detail.tsx
+++ b/apps/web/src/app/(dashboard)/cars/_components/makes/make-detail.tsx
@@ -7,11 +7,13 @@ import {
   CoeComparisonChart,
   MakeTrendChart,
 } from "@web/app/(dashboard)/cars/_components/makes";
+import { ShareButtons } from "@web/components/share-buttons";
 import { LastUpdated } from "@web/components/shared/last-updated";
 import NoData from "@web/components/shared/no-data";
 import { columns } from "@web/components/tables/columns/cars-make-columns";
 import Typography from "@web/components/typography";
 import { UnreleasedFeature } from "@web/components/unreleased-feature";
+import { SITE_TITLE, SITE_URL } from "@web/config";
 import type { MakeCoeComparisonData } from "@web/queries/cars/makes/coe-comparison";
 import type { Make } from "@web/types";
 import Image from "next/image";
@@ -57,7 +59,13 @@ export const MakeDetail = ({
           </div>
           <div className="flex flex-col items-start gap-2">
             {!!lastUpdated && <LastUpdated lastUpdated={lastUpdated} />}
-            <MakeSelector makes={makes} selectedMake={make} />
+            <div className="flex items-center gap-2">
+              <MakeSelector makes={makes} selectedMake={make} />
+              <ShareButtons
+                url={`${SITE_URL}/cars/makes/${make}`}
+                title={`${cars.make} Cars - ${SITE_TITLE}`}
+              />
+            </div>
           </div>
         </div>
       </div>

--- a/apps/web/src/app/(dashboard)/cars/deregistrations/page.tsx
+++ b/apps/web/src/app/(dashboard)/cars/deregistrations/page.tsx
@@ -10,6 +10,7 @@ import {
 import { TrendsChart } from "@web/app/(dashboard)/cars/deregistrations/_components/trends-chart";
 import { loadSearchParams } from "@web/app/(dashboard)/cars/deregistrations/search-params";
 import { PageHeader } from "@web/components/page-header";
+import { ShareButtons } from "@web/components/share-buttons";
 import { StructuredData } from "@web/components/structured-data";
 import Typography from "@web/components/typography";
 import { SITE_TITLE, SITE_URL } from "@web/config";
@@ -184,7 +185,12 @@ const DeregistrationsPage = async ({ searchParams }: Props) => {
       <StructuredData data={structuredData} />
       <div className="flex flex-col gap-8">
         {/* Header */}
-        <PageHeader title="Vehicle Deregistrations" />
+        <PageHeader title="Vehicle Deregistrations">
+          <ShareButtons
+            url={`${SITE_URL}/cars/deregistrations`}
+            title={`Vehicle Deregistrations - ${SITE_TITLE}`}
+          />
+        </PageHeader>
 
         {/* Interactive Category Chart */}
         <CategoryChart data={allDeregistrations} months={months} />

--- a/apps/web/src/app/(dashboard)/cars/makes/page.tsx
+++ b/apps/web/src/app/(dashboard)/cars/makes/page.tsx
@@ -2,6 +2,7 @@ import type { CarLogo } from "@logos/types";
 import { redis } from "@sgcarstrends/utils";
 import { MakesList } from "@web/app/(dashboard)/cars/_components/makes";
 import { PageHeader } from "@web/components/page-header";
+import { ShareButtons } from "@web/components/share-buttons";
 import { StructuredData } from "@web/components/structured-data";
 import { LAST_UPDATED_CARS_KEY, SITE_TITLE, SITE_URL } from "@web/config";
 import { createPageMetadata } from "@web/lib/metadata";
@@ -62,7 +63,12 @@ const CarMakesPage = async () => {
           subtitle="List of car makes registered in Singapore."
           lastUpdated={lastUpdated}
           months={months}
-        />
+        >
+          <ShareButtons
+            url={`${SITE_URL}/cars/makes`}
+            title={`Car Makes - ${SITE_TITLE}`}
+          />
+        </PageHeader>
         <Suspense fallback={null}>
           <MakesList makes={makes} popularMakes={popular} logos={logos} />
         </Suspense>

--- a/apps/web/src/app/(dashboard)/cars/page.tsx
+++ b/apps/web/src/app/(dashboard)/cars/page.tsx
@@ -3,6 +3,7 @@ import { CategoryTabs } from "@web/app/(dashboard)/cars/category-tabs";
 import { loadSearchParams } from "@web/app/(dashboard)/cars/search-params";
 import { CarRegistration } from "@web/app/(dashboard)/cars/trends-compare-button";
 import { PageHeader } from "@web/components/page-header";
+import { ShareButtons } from "@web/components/share-buttons";
 import { MetricCard } from "@web/components/shared/metric-card";
 import { StructuredData } from "@web/components/structured-data";
 import Typography from "@web/components/typography";
@@ -114,7 +115,12 @@ const CarsPage = async ({
           lastUpdated={lastUpdated}
           months={months}
           showMonthSelector={true}
-        />
+        >
+          <ShareButtons
+            url={`${SITE_URL}/cars?month=${month}`}
+            title={`${formattedMonth} Car Registrations - ${SITE_TITLE}`}
+          />
+        </PageHeader>
 
         <UnreleasedFeature>
           <CarRegistration />

--- a/apps/web/src/app/(dashboard)/coe/bidding/page.tsx
+++ b/apps/web/src/app/(dashboard)/coe/bidding/page.tsx
@@ -4,6 +4,7 @@ import {
   type Period,
 } from "@web/app/(dashboard)/coe/search-params";
 import { PageHeader } from "@web/components/page-header";
+import { ShareButtons } from "@web/components/share-buttons";
 import { StructuredData } from "@web/components/structured-data";
 import { TrendTable } from "@web/components/tables/coe-results-table";
 import Typography from "@web/components/typography";
@@ -72,7 +73,12 @@ const COEBiddingPageContent = async ({ period }: { period: Period }) => {
     <>
       <StructuredData data={structuredData} />
       <div className="flex flex-col gap-4">
-        <PageHeader title="Bidding Results" lastUpdated={lastUpdated} />
+        <PageHeader title="Bidding Results" lastUpdated={lastUpdated}>
+          <ShareButtons
+            url={`${SITE_URL}/coe/bidding`}
+            title={`COE Bidding Results - ${SITE_TITLE}`}
+          />
+        </PageHeader>
 
         <div className="grid grid-cols-1 gap-4">
           <Card>

--- a/apps/web/src/app/(dashboard)/coe/categories/[category]/page.tsx
+++ b/apps/web/src/app/(dashboard)/coe/categories/[category]/page.tsx
@@ -5,8 +5,10 @@ import {
   type Period,
 } from "@web/app/(dashboard)/coe/search-params";
 import { PageHeader } from "@web/components/page-header";
+import { ShareButtons } from "@web/components/share-buttons";
 import { StructuredData } from "@web/components/structured-data";
 import Typography from "@web/components/typography";
+import { SITE_TITLE, SITE_URL } from "@web/config";
 import {
   calculateCategoryStats,
   groupCOEResultsByBidding,
@@ -117,7 +119,12 @@ const COECategoryPageContent = async ({
     <>
       <StructuredData data={structuredData} />
       <div className="flex flex-col gap-4">
-        <PageHeader title={`${category} Analysis`} lastUpdated={lastUpdated} />
+        <PageHeader title={`${category} Analysis`} lastUpdated={lastUpdated}>
+          <ShareButtons
+            url={`${SITE_URL}/coe/categories/${categorySlug}`}
+            title={`COE ${category} Analysis - ${SITE_TITLE}`}
+          />
+        </PageHeader>
         <div className="grid grid-cols-1 gap-4">
           <COEPremiumChart data={data} />
         </div>

--- a/apps/web/src/app/(dashboard)/coe/page.tsx
+++ b/apps/web/src/app/(dashboard)/coe/page.tsx
@@ -5,6 +5,7 @@ import { PremiumRangeCard } from "@web/app/(dashboard)/coe/_components/premium-r
 import { AnimatedNumber } from "@web/components/animated-number";
 import { LatestCoePremium } from "@web/components/coe/latest-coe-premium";
 import { PageHeader } from "@web/components/page-header";
+import { ShareButtons } from "@web/components/share-buttons";
 import { StructuredData } from "@web/components/structured-data";
 import Typography from "@web/components/typography";
 import { SITE_TITLE, SITE_URL } from "@web/config";
@@ -88,7 +89,12 @@ const COEPricesPage = async () => {
     <>
       <StructuredData data={structuredData} />
       <div className="flex flex-col gap-6">
-        <PageHeader title="COE Overview" lastUpdated={lastUpdated} />
+        <PageHeader title="COE Overview" lastUpdated={lastUpdated}>
+          <ShareButtons
+            url={`${SITE_URL}/coe`}
+            title={`COE Overview - ${SITE_TITLE}`}
+          />
+        </PageHeader>
 
         <div className="grid grid-cols-1 gap-2 lg:grid-cols-3">
           <LatestCoePremium results={latestResults} trends={coeTrends} />

--- a/apps/web/src/app/(dashboard)/coe/pqp/page.tsx
+++ b/apps/web/src/app/(dashboard)/coe/pqp/page.tsx
@@ -8,9 +8,10 @@ import {
   TrendsChart,
 } from "@web/app/(dashboard)/coe/_components/pqp";
 import { PageHeader } from "@web/components/page-header";
+import { ShareButtons } from "@web/components/share-buttons";
 import { StructuredData } from "@web/components/structured-data";
 import { UnreleasedFeature } from "@web/components/unreleased-feature";
-import { LAST_UPDATED_COE_KEY, SITE_URL } from "@web/config";
+import { LAST_UPDATED_COE_KEY, SITE_TITLE, SITE_URL } from "@web/config";
 import { createPageMetadata } from "@web/lib/metadata";
 import { getPQPOverview } from "@web/queries/coe";
 import type { Pqp } from "@web/types/coe";
@@ -56,7 +57,12 @@ const PQPRatesPage = async () => {
       <StructuredData data={structuredData} />
       <div className="flex flex-col gap-4">
         <AnimatedSection order={0}>
-          <PageHeader title="PQP RATES" lastUpdated={lastUpdated} />
+          <PageHeader title="PQP RATES" lastUpdated={lastUpdated}>
+            <ShareButtons
+              url={`${SITE_URL}/coe/pqp`}
+              title={`COE PQP Rates - ${SITE_TITLE}`}
+            />
+          </PageHeader>
         </AnimatedSection>
 
         <AnimatedSection order={1}>

--- a/apps/web/src/app/(dashboard)/coe/results/page.tsx
+++ b/apps/web/src/app/(dashboard)/coe/results/page.tsx
@@ -6,8 +6,10 @@ import {
   type Period,
 } from "@web/app/(dashboard)/coe/search-params";
 import { PageHeader } from "@web/components/page-header";
+import { ShareButtons } from "@web/components/share-buttons";
 import { StructuredData } from "@web/components/structured-data";
 import { TrendTable } from "@web/components/tables/coe-results-table";
+import { SITE_TITLE, SITE_URL } from "@web/config";
 import { fetchCOEPageData } from "@web/lib/coe/page-data";
 import { createPageMetadata } from "@web/lib/metadata";
 import { createWebPageStructuredData } from "@web/lib/metadata/structured-data";
@@ -64,7 +66,12 @@ const COEResultsPageContent = async ({ period }: { period: Period }) => {
     <>
       <StructuredData data={structuredData} />
       <div className="flex flex-col gap-4">
-        <PageHeader title="Historical Results" lastUpdated={lastUpdated} />
+        <PageHeader title="Historical Results" lastUpdated={lastUpdated}>
+          <ShareButtons
+            url={`${SITE_URL}/coe/results`}
+            title={`COE Historical Results - ${SITE_TITLE}`}
+          />
+        </PageHeader>
         <div className="grid grid-cols-1 gap-4 xl:grid-cols-12">
           <div className="xl:col-span-9">
             <COEPremiumChart data={data} />

--- a/apps/web/src/app/(dashboard)/coe/trends/page.tsx
+++ b/apps/web/src/app/(dashboard)/coe/trends/page.tsx
@@ -6,8 +6,10 @@ import {
   type Period,
 } from "@web/app/(dashboard)/coe/search-params";
 import { PageHeader } from "@web/components/page-header";
+import { ShareButtons } from "@web/components/share-buttons";
 import { StructuredData } from "@web/components/structured-data";
 import Typography from "@web/components/typography";
+import { SITE_TITLE, SITE_URL } from "@web/config";
 import { calculateTrendInsights } from "@web/lib/coe/calculations";
 import { fetchCOEPageData } from "@web/lib/coe/page-data";
 import { createPageMetadata } from "@web/lib/metadata";
@@ -53,7 +55,12 @@ const COETrendsPageContent = async ({ period }: { period: Period }) => {
     <>
       <StructuredData data={structuredData} />
       <div className="flex flex-col gap-4">
-        <PageHeader title="Trends Analysis" lastUpdated={lastUpdated} />
+        <PageHeader title="Trends Analysis" lastUpdated={lastUpdated}>
+          <ShareButtons
+            url={`${SITE_URL}/coe/trends`}
+            title={`COE Trends Analysis - ${SITE_TITLE}`}
+          />
+        </PageHeader>
 
         <div className="grid grid-cols-1 gap-4 xl:grid-cols-12">
           <div className="xl:col-span-9">

--- a/apps/web/src/app/blog/[slug]/page.tsx
+++ b/apps/web/src/app/blog/[slug]/page.tsx
@@ -170,6 +170,7 @@ const BlogPostPage = async ({ params }: Props) => {
         {/* Bloomberg-style Hero with overlaid title */}
         <BlogHero
           title={post.title}
+          slug={post.slug}
           heroImage={heroImage}
           publishedAt={publishedDate}
           readingTimeText={readingTimeText}

--- a/apps/web/src/app/blog/_components/blog-hero.tsx
+++ b/apps/web/src/app/blog/_components/blog-hero.tsx
@@ -1,9 +1,12 @@
 import { ViewCounter } from "@web/app/blog/_components/view-counter";
+import { ShareButtons } from "@web/components/share-buttons";
+import { SITE_URL } from "@web/config";
 import Image from "next/image";
 import { Suspense } from "react";
 
 interface BlogHeroProps {
   title: string;
+  slug: string;
   heroImage: string;
   publishedAt: Date;
   readingTimeText: string;
@@ -14,6 +17,7 @@ interface BlogHeroProps {
 
 export const BlogHero = ({
   title,
+  slug,
   heroImage,
   publishedAt,
   readingTimeText,
@@ -22,6 +26,7 @@ export const BlogHero = ({
   initialViewCount,
 }: BlogHeroProps) => {
   const categoryLabel = tags.length > 0 ? tags[0] : "Market Analysis";
+  const shareUrl = `${SITE_URL}/blog/${slug}`;
 
   return (
     <div className="relative mb-12 aspect-[4/3] w-full overflow-hidden md:aspect-[21/9]">
@@ -58,6 +63,12 @@ export const BlogHero = ({
               className="text-inherit"
             />
           </Suspense>
+          <span className="size-2 rounded-full bg-white/50" />
+          <ShareButtons
+            url={shareUrl}
+            title={title}
+            className="text-white/80 hover:bg-white/10 hover:text-white"
+          />
         </div>
       </div>
     </div>

--- a/apps/web/src/components/__tests__/share-buttons.test.tsx
+++ b/apps/web/src/components/__tests__/share-buttons.test.tsx
@@ -1,0 +1,98 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { ShareButtons } from "@web/components/share-buttons";
+
+// Mock clipboard API
+Object.defineProperty(navigator, "clipboard", {
+  value: {
+    writeText: vi.fn().mockResolvedValue(undefined),
+  },
+  writable: true,
+});
+
+// Mock addToast
+vi.mock("@heroui/toast", () => ({
+  addToast: vi.fn(),
+}));
+
+// Mock window.open
+const mockWindowOpen = vi.fn();
+Object.defineProperty(window, "open", {
+  value: mockWindowOpen,
+  writable: true,
+});
+
+describe("ShareButtons", () => {
+  const defaultProps = {
+    url: "https://sgcarstrends.com/cars",
+    title: "Car Registrations - SG Cars Trends",
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should render both mobile and desktop share buttons", () => {
+    render(<ShareButtons {...defaultProps} />);
+
+    // Mobile share button
+    expect(screen.getByLabelText("Share")).toBeInTheDocument();
+
+    // Desktop buttons
+    expect(screen.getByLabelText("Share on X")).toBeInTheDocument();
+    expect(screen.getByLabelText("Share on LinkedIn")).toBeInTheDocument();
+    expect(screen.getByLabelText("Copy link")).toBeInTheDocument();
+  });
+
+  it("should open Twitter share URL when X button is clicked", () => {
+    render(<ShareButtons {...defaultProps} />);
+
+    const twitterButton = screen.getByLabelText("Share on X");
+    fireEvent.click(twitterButton);
+
+    expect(mockWindowOpen).toHaveBeenCalled();
+    const [url, target] = mockWindowOpen.mock.calls[0];
+    expect(url).toContain("twitter.com/intent/tweet");
+    expect(url).toContain(encodeURIComponent(defaultProps.url));
+    expect(target).toBe("_blank");
+  });
+
+  it("should open LinkedIn share URL when LinkedIn button is clicked", () => {
+    render(<ShareButtons {...defaultProps} />);
+
+    const linkedinButton = screen.getByLabelText("Share on LinkedIn");
+    fireEvent.click(linkedinButton);
+
+    expect(mockWindowOpen).toHaveBeenCalled();
+    const [url, target] = mockWindowOpen.mock.calls[0];
+    expect(url).toContain("linkedin.com/sharing/share-offsite");
+    expect(url).toContain(encodeURIComponent(defaultProps.url));
+    expect(target).toBe("_blank");
+  });
+
+  it("should copy link to clipboard when copy button is clicked", async () => {
+    render(<ShareButtons {...defaultProps} />);
+
+    const copyButton = screen.getByLabelText("Copy link");
+    fireEvent.click(copyButton);
+
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+      defaultProps.url,
+    );
+  });
+
+  it("should apply custom className", () => {
+    render(<ShareButtons {...defaultProps} className="custom-class" />);
+
+    const buttons = screen.getAllByRole("button");
+    buttons.forEach((button) => {
+      expect(button).toHaveClass("custom-class");
+    });
+  });
+
+  it("should render 4 buttons total (1 mobile + 3 desktop)", () => {
+    render(<ShareButtons {...defaultProps} />);
+
+    const buttons = screen.getAllByRole("button");
+    expect(buttons).toHaveLength(4);
+  });
+});

--- a/apps/web/src/components/__tests__/share-buttons.test.tsx
+++ b/apps/web/src/components/__tests__/share-buttons.test.tsx
@@ -14,13 +14,6 @@ vi.mock("@heroui/toast", () => ({
   addToast: vi.fn(),
 }));
 
-// Mock window.open
-const mockWindowOpen = vi.fn();
-Object.defineProperty(window, "open", {
-  value: mockWindowOpen,
-  writable: true,
-});
-
 describe("ShareButtons", () => {
   const defaultProps = {
     url: "https://sgcarstrends.com/cars",
@@ -43,30 +36,38 @@ describe("ShareButtons", () => {
     expect(screen.getByLabelText("Copy link")).toBeInTheDocument();
   });
 
-  it("should open Twitter share URL when X button is clicked", () => {
+  it("should have correct Twitter share URL as anchor", () => {
     render(<ShareButtons {...defaultProps} />);
 
-    const twitterButton = screen.getByLabelText("Share on X");
-    fireEvent.click(twitterButton);
+    const twitterLink = screen.getByLabelText("Share on X");
 
-    expect(mockWindowOpen).toHaveBeenCalled();
-    const [url, target] = mockWindowOpen.mock.calls[0];
-    expect(url).toContain("twitter.com/intent/tweet");
-    expect(url).toContain(encodeURIComponent(defaultProps.url));
-    expect(target).toBe("_blank");
+    expect(twitterLink).toHaveAttribute(
+      "href",
+      expect.stringContaining("twitter.com/intent/tweet"),
+    );
+    expect(twitterLink).toHaveAttribute(
+      "href",
+      expect.stringContaining(encodeURIComponent(defaultProps.url)),
+    );
+    expect(twitterLink).toHaveAttribute("target", "_blank");
+    expect(twitterLink).toHaveAttribute("rel", "noopener noreferrer");
   });
 
-  it("should open LinkedIn share URL when LinkedIn button is clicked", () => {
+  it("should have correct LinkedIn share URL as anchor", () => {
     render(<ShareButtons {...defaultProps} />);
 
-    const linkedinButton = screen.getByLabelText("Share on LinkedIn");
-    fireEvent.click(linkedinButton);
+    const linkedinLink = screen.getByLabelText("Share on LinkedIn");
 
-    expect(mockWindowOpen).toHaveBeenCalled();
-    const [url, target] = mockWindowOpen.mock.calls[0];
-    expect(url).toContain("linkedin.com/sharing/share-offsite");
-    expect(url).toContain(encodeURIComponent(defaultProps.url));
-    expect(target).toBe("_blank");
+    expect(linkedinLink).toHaveAttribute(
+      "href",
+      expect.stringContaining("linkedin.com/sharing/share-offsite"),
+    );
+    expect(linkedinLink).toHaveAttribute(
+      "href",
+      expect.stringContaining(encodeURIComponent(defaultProps.url)),
+    );
+    expect(linkedinLink).toHaveAttribute("target", "_blank");
+    expect(linkedinLink).toHaveAttribute("rel", "noopener noreferrer");
   });
 
   it("should copy link to clipboard when copy button is clicked", async () => {
@@ -83,15 +84,25 @@ describe("ShareButtons", () => {
   it("should apply custom className", () => {
     render(<ShareButtons {...defaultProps} className="custom-class" />);
 
-    const buttons = screen.getAllByRole("button");
-    buttons.forEach((button) => {
-      expect(button).toHaveClass("custom-class");
-    });
+    // Check mobile button
+    const mobileButton = screen.getByLabelText("Share");
+    expect(mobileButton).toHaveClass("custom-class");
+
+    // Check desktop links and button
+    const twitterLink = screen.getByLabelText("Share on X");
+    const linkedinLink = screen.getByLabelText("Share on LinkedIn");
+    const copyButton = screen.getByLabelText("Copy link");
+
+    expect(twitterLink).toHaveClass("custom-class");
+    expect(linkedinLink).toHaveClass("custom-class");
+    expect(copyButton).toHaveClass("custom-class");
   });
 
-  it("should render 4 buttons total (1 mobile + 3 desktop)", () => {
+  it("should render 4 interactive elements", () => {
     render(<ShareButtons {...defaultProps} />);
 
+    // 4 buttons total: mobile share, twitter (as="a"), linkedin (as="a"), copy link
+    // HeroUI Button with as="a" still has role="button"
     const buttons = screen.getAllByRole("button");
     expect(buttons).toHaveLength(4);
   });

--- a/apps/web/src/components/share-buttons.tsx
+++ b/apps/web/src/components/share-buttons.tsx
@@ -76,7 +76,7 @@ export const ShareButtons = ({ url, title, className }: ShareButtonsProps) => {
               className={buttonClassName}
               aria-label={label}
             >
-              <Icon className="size-4" />
+              <Icon className="size-4" color="currentColor" />
             </Button>
           </Tooltip>
         ))}

--- a/apps/web/src/components/share-buttons.tsx
+++ b/apps/web/src/components/share-buttons.tsx
@@ -33,18 +33,6 @@ const SHARE_PLATFORMS: ShareButtonConfig[] = [
 export const ShareButtons = ({ url, title, className }: ShareButtonsProps) => {
   const [copied, setCopied] = useState(false);
 
-  const handleShare = useCallback(
-    (platform: SharePlatform) => {
-      const shareUrl = getShareUrl({ platform, url, title });
-      window.open(
-        shareUrl,
-        "_blank",
-        "noopener,noreferrer,width=600,height=400",
-      );
-    },
-    [url, title],
-  );
-
   const handleCopyLink = useCallback(async () => {
     const success = await copyToClipboard(url);
     if (success) {
@@ -78,11 +66,14 @@ export const ShareButtons = ({ url, title, className }: ShareButtonsProps) => {
         {SHARE_PLATFORMS.map(({ platform, label, icon: Icon }) => (
           <Tooltip key={platform} content={label}>
             <Button
+              as="a"
+              href={getShareUrl({ platform, url, title })}
+              target="_blank"
+              rel="noopener noreferrer"
               isIconOnly
               variant="light"
               size="sm"
               className={buttonClassName}
-              onPress={() => handleShare(platform)}
               aria-label={label}
             >
               <Icon className="size-4" />

--- a/apps/web/src/components/share-buttons.tsx
+++ b/apps/web/src/components/share-buttons.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import { Button } from "@heroui/button";
+import { cn } from "@heroui/theme";
+import { Tooltip } from "@heroui/tooltip";
+import { type IconType, SiLinkedin, SiX } from "@icons-pack/react-simple-icons";
+import {
+  copyToClipboard,
+  getShareUrl,
+  type SharePlatform,
+  triggerWebShare,
+} from "@web/utils/share";
+import { Check, Link2, Share2 } from "lucide-react";
+import { useCallback, useState } from "react";
+
+interface ShareButtonsProps {
+  url: string;
+  title: string;
+  className?: string;
+}
+
+interface ShareButtonConfig {
+  platform: SharePlatform;
+  label: string;
+  icon: IconType;
+}
+
+const SHARE_PLATFORMS: ShareButtonConfig[] = [
+  { platform: "twitter", label: "Share on X", icon: SiX },
+  { platform: "linkedin", label: "Share on LinkedIn", icon: SiLinkedin },
+];
+
+export const ShareButtons = ({ url, title, className }: ShareButtonsProps) => {
+  const [copied, setCopied] = useState(false);
+
+  const handleShare = useCallback(
+    (platform: SharePlatform) => {
+      const shareUrl = getShareUrl({ platform, url, title });
+      window.open(
+        shareUrl,
+        "_blank",
+        "noopener,noreferrer,width=600,height=400",
+      );
+    },
+    [url, title],
+  );
+
+  const handleCopyLink = useCallback(async () => {
+    const success = await copyToClipboard(url);
+    if (success) {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    }
+  }, [url]);
+
+  const handleNativeShare = useCallback(async () => {
+    await triggerWebShare(url, title);
+  }, [url, title]);
+
+  const buttonClassName = cn("text-default-500 hover:text-primary", className);
+
+  return (
+    <>
+      {/* Mobile */}
+      <Button
+        isIconOnly
+        variant="light"
+        size="sm"
+        className={cn(buttonClassName, "flex md:hidden")}
+        onPress={handleNativeShare}
+        aria-label="Share"
+      >
+        <Share2 className="size-4" />
+      </Button>
+
+      {/* Desktop */}
+      <div className="hidden items-center gap-2 md:flex">
+        {SHARE_PLATFORMS.map(({ platform, label, icon: Icon }) => (
+          <Tooltip key={platform} content={label}>
+            <Button
+              isIconOnly
+              variant="light"
+              size="sm"
+              className={buttonClassName}
+              onPress={() => handleShare(platform)}
+              aria-label={label}
+            >
+              <Icon className="size-4" />
+            </Button>
+          </Tooltip>
+        ))}
+        <Tooltip content={copied ? "Copied!" : "Copy link"}>
+          <Button
+            isIconOnly
+            variant="light"
+            size="sm"
+            className={buttonClassName}
+            onPress={handleCopyLink}
+            aria-label="Copy link"
+          >
+            {copied ? (
+              <Check className="size-4 text-success" />
+            ) : (
+              <Link2 className="size-4" />
+            )}
+          </Button>
+        </Tooltip>
+      </div>
+    </>
+  );
+};

--- a/apps/web/src/utils/__tests__/share.test.ts
+++ b/apps/web/src/utils/__tests__/share.test.ts
@@ -1,0 +1,69 @@
+import { canUseWebShare, getShareUrl } from "@web/utils/share";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+describe("getShareUrl", () => {
+  const url = "https://sgcarstrends.com/cars";
+  const title = "Car Registrations";
+
+  it("should generate correct Twitter share URL", () => {
+    const result = getShareUrl({ platform: "twitter", url, title });
+    expect(result).toBe(
+      `https://twitter.com/intent/tweet?url=${encodeURIComponent(url)}&text=${encodeURIComponent(title)}`,
+    );
+  });
+
+  it("should generate correct LinkedIn share URL", () => {
+    const result = getShareUrl({ platform: "linkedin", url, title });
+    expect(result).toBe(
+      `https://www.linkedin.com/sharing/share-offsite/?url=${encodeURIComponent(url)}`,
+    );
+  });
+
+  it("should handle special characters in URL and title", () => {
+    const specialUrl =
+      "https://sgcarstrends.com/cars?month=2024-01&filter=test";
+    const specialTitle = "Car Registrations: January 2024 & More";
+    const result = getShareUrl({
+      platform: "twitter",
+      url: specialUrl,
+      title: specialTitle,
+    });
+    expect(result).toContain(encodeURIComponent(specialUrl));
+    expect(result).toContain(encodeURIComponent(specialTitle));
+  });
+});
+
+describe("canUseWebShare", () => {
+  const originalNavigator = global.navigator;
+
+  afterEach(() => {
+    Object.defineProperty(global, "navigator", {
+      value: originalNavigator,
+      writable: true,
+    });
+  });
+
+  it("should return true when Web Share API is available", () => {
+    Object.defineProperty(global, "navigator", {
+      value: { share: vi.fn() },
+      writable: true,
+    });
+    expect(canUseWebShare()).toBe(true);
+  });
+
+  it("should return false when navigator is undefined", () => {
+    Object.defineProperty(global, "navigator", {
+      value: undefined,
+      writable: true,
+    });
+    expect(canUseWebShare()).toBe(false);
+  });
+
+  it("should return false when share is not a function", () => {
+    Object.defineProperty(global, "navigator", {
+      value: { share: undefined },
+      writable: true,
+    });
+    expect(canUseWebShare()).toBe(false);
+  });
+});

--- a/apps/web/src/utils/share.ts
+++ b/apps/web/src/utils/share.ts
@@ -1,0 +1,80 @@
+import { addToast } from "@heroui/toast";
+
+export type SharePlatform = "twitter" | "linkedin";
+
+interface ShareUrlParams {
+  platform: SharePlatform;
+  url: string;
+  title: string;
+}
+
+/**
+ * Generate platform-specific share URLs
+ */
+export const getShareUrl = ({
+  platform,
+  url,
+  title,
+}: ShareUrlParams): string => {
+  const encodedUrl = encodeURIComponent(url);
+  const encodedTitle = encodeURIComponent(title);
+
+  const shareUrls: Record<SharePlatform, string> = {
+    twitter: `https://twitter.com/intent/tweet?url=${encodedUrl}&text=${encodedTitle}`,
+    linkedin: `https://www.linkedin.com/sharing/share-offsite/?url=${encodedUrl}`,
+  };
+
+  return shareUrls[platform];
+};
+
+/**
+ * Copy URL to clipboard with toast feedback
+ */
+export const copyToClipboard = async (url: string): Promise<boolean> => {
+  try {
+    await navigator.clipboard.writeText(url);
+    addToast({
+      title: "Link copied to clipboard",
+      variant: "bordered",
+    });
+    return true;
+  } catch {
+    addToast({
+      title: "Failed to copy link",
+      variant: "bordered",
+    });
+    return false;
+  }
+};
+
+/**
+ * Check if Web Share API is available
+ */
+export const canUseWebShare = (): boolean => {
+  return (
+    typeof navigator !== "undefined" && typeof navigator.share === "function"
+  );
+};
+
+/**
+ * Trigger native Web Share API
+ */
+export const triggerWebShare = async (
+  url: string,
+  title: string,
+): Promise<boolean> => {
+  if (!canUseWebShare()) {
+    return false;
+  }
+
+  try {
+    await navigator.share({ title, url });
+    return true;
+  } catch (error) {
+    // User cancelled or share failed - AbortError is expected when user cancels
+    if ((error as Error).name !== "AbortError") {
+      console.error("Share failed:", error);
+    }
+    return false;
+  }
+};


### PR DESCRIPTION
## Summary
- Add social share buttons (X, LinkedIn, Facebook, Copy Link) to all dashboard pages and blog posts
- Includes comprehensive test coverage for share functionality and components