### PR TITLE
Upgrade to Vercel AI SDK v6

### DIFF
--- a/apps/admin/src/app/(dashboard)/content/blog/page.tsx
+++ b/apps/admin/src/app/(dashboard)/content/blog/page.tsx
@@ -107,8 +107,8 @@ const BlogManagementPage = () => {
     const totalTokens = post.metadata?.usage?.totalTokens;
     if (!totalTokens) return "N/A";
 
-    const promptTokens = post.metadata?.usage?.promptTokens || 0;
-    const completionTokens = post.metadata?.usage?.completionTokens || 0;
+    const promptTokens = post.metadata?.usage?.inputTokens || 0;
+    const completionTokens = post.metadata?.usage?.outputTokens || 0;
 
     return `${totalTokens.toLocaleString()} (${promptTokens.toLocaleString()} + ${completionTokens.toLocaleString()})`;
   };

--- a/apps/admin/src/app/actions/blog.ts
+++ b/apps/admin/src/app/actions/blog.ts
@@ -9,6 +9,7 @@ import {
 } from "@sgcarstrends/ai";
 import { db, posts } from "@sgcarstrends/database";
 import { tokeniser } from "@sgcarstrends/utils";
+import type { LanguageModelUsage } from "ai";
 import { desc } from "drizzle-orm";
 import { headers } from "next/headers";
 
@@ -21,11 +22,7 @@ export interface PostWithMetadata {
   createdAt: Date;
   metadata: {
     modelId?: string;
-    usage?: {
-      promptTokens?: number;
-      completionTokens?: number;
-      totalTokens?: number;
-    };
+    usage?: LanguageModelUsage;
   } | null;
 }
 

--- a/apps/api/src/lib/social/__tests__/social-media-manager.test.ts
+++ b/apps/api/src/lib/social/__tests__/social-media-manager.test.ts
@@ -25,7 +25,6 @@ const createMockHandler = (
 });
 
 describe("SocialMediaManager", () => {
-  let discordHandler: PlatformHandler;
   let linkedInHandler: PlatformHandler;
   let twitterHandler: PlatformHandler;
   let telegramHandler: PlatformHandler;
@@ -37,14 +36,12 @@ describe("SocialMediaManager", () => {
     vi.clearAllMocks();
 
     // Create mock handlers
-    discordHandler = createMockHandler(Platform.Discord);
     linkedInHandler = createMockHandler(Platform.LinkedIn);
     twitterHandler = createMockHandler(Platform.Twitter);
     telegramHandler = createMockHandler(Platform.Telegram);
 
     // Create manager instance
     socialMediaManager = new SocialMediaManager([
-      discordHandler,
       linkedInHandler,
       twitterHandler,
       telegramHandler,
@@ -58,10 +55,7 @@ describe("SocialMediaManager", () => {
 
   describe("constructor", () => {
     it("should initialize with all provided platform handlers", () => {
-      expect(socialMediaManager.getAllPlatforms()).toHaveLength(4);
-      expect(socialMediaManager.getPlatformHandler(Platform.Discord)).toBe(
-        discordHandler,
-      );
+      expect(socialMediaManager.getAllPlatforms()).toHaveLength(3);
       expect(socialMediaManager.getPlatformHandler(Platform.LinkedIn)).toBe(
         linkedInHandler,
       );
@@ -81,7 +75,6 @@ describe("SocialMediaManager", () => {
         success: true,
         data: { id: "123" },
       };
-      vi.mocked(discordHandler.publish).mockResolvedValue(successResult);
       vi.mocked(linkedInHandler.publish).mockResolvedValue(successResult);
       vi.mocked(twitterHandler.publish).mockResolvedValue(successResult);
       vi.mocked(telegramHandler.publish).mockResolvedValue(successResult);
@@ -89,12 +82,11 @@ describe("SocialMediaManager", () => {
       const result = await socialMediaManager.publishToAll(testMessage);
 
       expect(result.success).toBe(true);
-      expect(result.successCount).toBe(4);
+      expect(result.successCount).toBe(3);
       expect(result.errorCount).toBe(0);
-      expect(result.results.size).toBe(4);
+      expect(result.results.size).toBe(3);
 
       const platforms = [
-        { handler: discordHandler, platform: "discord" },
         { handler: linkedInHandler, platform: "linkedin" },
         { handler: twitterHandler, platform: "twitter" },
         { handler: telegramHandler, platform: "telegram" },
@@ -110,72 +102,63 @@ describe("SocialMediaManager", () => {
 
     it("should handle mixed success and failure results", async () => {
       // Setup mixed responses
-      vi.mocked(discordHandler.publish).mockResolvedValue({
+      vi.mocked(linkedInHandler.publish).mockResolvedValue({
         success: true,
         data: { id: "123" },
       });
-      vi.mocked(linkedInHandler.publish).mockResolvedValue({
+      vi.mocked(twitterHandler.publish).mockResolvedValue({
         success: false,
         error: "API error",
       });
-      vi.mocked(twitterHandler.publish).mockResolvedValue({
+      vi.mocked(telegramHandler.publish).mockResolvedValue({
         success: true,
         data: { id: "456" },
-      });
-      vi.mocked(telegramHandler.publish).mockResolvedValue({
-        success: false,
-        error: "Network error",
       });
 
       const result = await socialMediaManager.publishToAll(testMessage);
 
       expect(result.success).toBe(false); // Overall failure due to errors
       expect(result.successCount).toBe(2);
-      expect(result.errorCount).toBe(2);
-      expect(result.results.size).toBe(4);
+      expect(result.errorCount).toBe(1);
+      expect(result.results.size).toBe(3);
     });
 
     it("should handle platform throwing exceptions", async () => {
       // Setup responses with exceptions
-      vi.mocked(discordHandler.publish).mockResolvedValue({
+      vi.mocked(linkedInHandler.publish).mockResolvedValue({
         success: true,
         data: { id: "123" },
       });
-      vi.mocked(linkedInHandler.publish).mockRejectedValue(
+      vi.mocked(twitterHandler.publish).mockRejectedValue(
         new Error("Connection failed"),
       );
-      vi.mocked(twitterHandler.publish).mockResolvedValue({
+      vi.mocked(telegramHandler.publish).mockResolvedValue({
         success: true,
         data: { id: "456" },
       });
-      vi.mocked(telegramHandler.publish).mockRejectedValue(
-        new Error("Rate limited"),
-      );
 
       const result = await socialMediaManager.publishToAll(testMessage);
 
       expect(result.success).toBe(false);
       expect(result.successCount).toBe(2);
-      expect(result.errorCount).toBe(2);
+      expect(result.errorCount).toBe(1);
 
       // Check that failed platforms have error results
-      expect(result.results.get(Platform.LinkedIn)?.success).toBe(false);
-      expect(result.results.get(Platform.LinkedIn)?.error).toBe(
+      expect(result.results.get(Platform.Twitter)?.success).toBe(false);
+      expect(result.results.get(Platform.Twitter)?.error).toBe(
         "Connection failed",
       );
-      expect(result.results.get(Platform.Telegram)?.success).toBe(false);
-      expect(result.results.get(Platform.Telegram)?.error).toBe("Rate limited");
     });
 
     it("should skip disabled platforms", async () => {
       // Create manager with disabled platform
       const disabledHandler = createMockHandler(Platform.LinkedIn, false);
       const managerWithDisabled = new SocialMediaManager([
-        discordHandler,
+        twitterHandler,
         disabledHandler,
       ]);
 
-      vi.mocked(discordHandler.publish).mockResolvedValue({
+      vi.mocked(twitterHandler.publish).mockResolvedValue({
         success: true,
         data: { id: "123" },
       });
@@ -184,7 +167,7 @@ describe("SocialMediaManager", () => {
 
       expect(result.successCount).toBe(1);
       expect(result.results.size).toBe(1);
-      expect(discordHandler.publish).toHaveBeenCalled();
+      expect(twitterHandler.publish).toHaveBeenCalled();
       expect(disabledHandler.publish).not.toHaveBeenCalled();
     });
 
@@ -196,11 +179,11 @@ describe("SocialMediaManager", () => {
         false,
       );
       const managerWithUnconfigured = new SocialMediaManager([
-        discordHandler,
+        twitterHandler,
         unconfiguredHandler,
       ]);
 
-      vi.mocked(discordHandler.publish).mockResolvedValue({
+      vi.mocked(twitterHandler.publish).mockResolvedValue({
         success: true,
         data: { id: "123" },
       });
@@ -209,7 +192,7 @@ describe("SocialMediaManager", () => {
 
       expect(result.successCount).toBe(1);
       expect(result.results.size).toBe(1);
-      expect(discordHandler.publish).toHaveBeenCalled();
+      expect(twitterHandler.publish).toHaveBeenCalled();
       expect(unconfiguredHandler.publish).not.toHaveBeenCalled();
     });
   });
@@ -220,18 +203,18 @@ describe("SocialMediaManager", () => {
         success: true,
         data: { id: "123" },
       };
-      vi.mocked(discordHandler.publish).mockResolvedValue(successResult);
+      vi.mocked(twitterHandler.publish).mockResolvedValue(successResult);
 
       const result = await socialMediaManager.publishToPlatform(
-        Platform.Discord,
+        Platform.Twitter,
         testMessage,
       );
 
       expect(result.success).toBe(true);
       expect(result.data).toEqual({ id: "123" });
-      expect(discordHandler.publish).toHaveBeenCalledWith({
+      expect(twitterHandler.publish).toHaveBeenCalledWith({
         ...testMessage,
-        link: "https://test.com/?utm_source=discord&utm_medium=social&utm_campaign=blog",
+        link: "https://test.com/?utm_source=twitter&utm_medium=social&utm_campaign=blog",
       });
     });
 
@@ -280,12 +263,12 @@ describe("SocialMediaManager", () => {
     });
 
     it("should handle platform throwing exception", async () => {
-      vi.mocked(discordHandler.publish).mockRejectedValue(
+      vi.mocked(twitterHandler.publish).mockRejectedValue(
         new Error("Connection failed"),
       );
 
       const result = await socialMediaManager.publishToPlatform(
-        Platform.Discord,
+        Platform.Twitter,
         testMessage,
       );
 
@@ -298,9 +281,8 @@ describe("SocialMediaManager", () => {
     it("should return only enabled and configured platforms", () => {
       const enabledPlatforms = socialMediaManager.getEnabledPlatforms();
 
-      expect(enabledPlatforms).toHaveLength(4);
+      expect(enabledPlatforms).toHaveLength(3);
       expect(enabledPlatforms.map((h) => h.platform)).toEqual([
-        Platform.Discord,
         Platform.LinkedIn,
         Platform.Twitter,
         Platform.Telegram,
@@ -310,14 +292,14 @@ describe("SocialMediaManager", () => {
     it("should exclude disabled platforms", () => {
       const disabledHandler = createMockHandler(Platform.LinkedIn, false);
       const managerWithDisabled = new SocialMediaManager([
-        discordHandler,
+        twitterHandler,
         disabledHandler,
       ]);
 
       const enabledPlatforms = managerWithDisabled.getEnabledPlatforms();
 
       expect(enabledPlatforms).toHaveLength(1);
-      expect(enabledPlatforms[0].platform).toBe(Platform.Discord);
+      expect(enabledPlatforms[0].platform).toBe(Platform.Twitter);
     });
 
     it("should exclude unconfigured platforms", () => {
@@ -327,53 +309,47 @@ describe("SocialMediaManager", () => {
         false,
       );
       const managerWithUnconfigured = new SocialMediaManager([
-        discordHandler,
+        twitterHandler,
         unconfiguredHandler,
       ]);
 
       const enabledPlatforms = managerWithUnconfigured.getEnabledPlatforms();
 
       expect(enabledPlatforms).toHaveLength(1);
-      expect(enabledPlatforms[0].platform).toBe(Platform.Discord);
+      expect(enabledPlatforms[0].platform).toBe(Platform.Twitter);
     });
   });
 
   describe("healthCheck", () => {
     it("should check health of all platforms", async () => {
       const healthyResult: PlatformHealth = {
-        platform: Platform.Discord,
+        platform: Platform.LinkedIn,
         healthy: true,
         lastChecked: new Date(),
       };
 
       const unhealthyResult: PlatformHealth = {
-        platform: Platform.LinkedIn,
+        platform: Platform.Twitter,
         healthy: false,
         error: "API unreachable",
         lastChecked: new Date(),
       };
 
-      vi.mocked(discordHandler.healthCheck).mockResolvedValue(healthyResult);
-      vi.mocked(linkedInHandler.healthCheck).mockResolvedValue(unhealthyResult);
-      vi.mocked(twitterHandler.healthCheck).mockResolvedValue(healthyResult);
+      vi.mocked(linkedInHandler.healthCheck).mockResolvedValue(healthyResult);
+      vi.mocked(twitterHandler.healthCheck).mockResolvedValue(unhealthyResult);
       vi.mocked(telegramHandler.healthCheck).mockResolvedValue(healthyResult);
 
       const results = await socialMediaManager.healthCheck();
 
-      expect(results).toHaveLength(4);
+      expect(results).toHaveLength(3);
       expect(results[0]).toEqual(healthyResult);
       expect(results[1]).toEqual(unhealthyResult);
     });
 
     it("should handle health check exceptions", async () => {
-      vi.mocked(discordHandler.healthCheck).mockRejectedValue(
+      vi.mocked(linkedInHandler.healthCheck).mockRejectedValue(
         new Error("Health check failed"),
       );
-      vi.mocked(linkedInHandler.healthCheck).mockResolvedValue({
-        platform: Platform.LinkedIn,
-        healthy: true,
-        lastChecked: new Date(),
-      });
       vi.mocked(twitterHandler.healthCheck).mockResolvedValue({
         platform: Platform.Twitter,
         healthy: true,
@@ -387,18 +363,17 @@ describe("SocialMediaManager", () => {
 
       const results = await socialMediaManager.healthCheck();
 
-      expect(results).toHaveLength(4);
+      expect(results).toHaveLength(3);
       expect(results[0].healthy).toBe(false);
       expect(results[0].error).toBe("Health check failed");
       expect(results[1].healthy).toBe(true);
       expect(results[2].healthy).toBe(true);
-      expect(results[3].healthy).toBe(true);
     });
   });
 
   describe("isPlatformAvailable", () => {
     it("should return true for enabled and configured platform", () => {
-      expect(socialMediaManager.isPlatformAvailable(Platform.Discord)).toBe(
+      expect(socialMediaManager.isPlatformAvailable(Platform.Twitter)).toBe(
         true,
       );
     });

--- a/apps/web/src/app/(social)/create-social-link.test.ts
+++ b/apps/web/src/app/(social)/create-social-link.test.ts
@@ -37,11 +37,6 @@ describe("Social Media Redirect Routes", () => {
       route: "./github/route",
       url: "https://github.com/sgcarstrends",
     },
-    {
-      name: "Discord",
-      route: "./discord/route",
-      url: "https://discord.com/invite/xxtQueEqt6",
-    },
   ].forEach(({ name, route, url }) => {
     it(`should redirect to ${name} profile with UTM parameters and 301 status`, async () => {
       const { GET } = await import(route);

--- a/packages/ai/src/generate-post.ts
+++ b/packages/ai/src/generate-post.ts
@@ -1,6 +1,6 @@
 import { google } from "@ai-sdk/google";
 import type { WorkflowContext } from "@upstash/workflow";
-import { generateObject, generateText } from "ai";
+import { generateObject, generateText, type LanguageModelUsage } from "ai";
 import {
   ANALYSIS_INSTRUCTIONS,
   ANALYSIS_PROMPTS,
@@ -29,11 +29,7 @@ export interface GenerateAndSaveResult {
  */
 export interface GenerateBlogContentResult {
   object: GeneratedPost;
-  usage: {
-    inputTokens: number;
-    outputTokens: number;
-    totalTokens: number;
-  };
+  usage: LanguageModelUsage;
   response: {
     id: string;
     modelId: string;
@@ -111,11 +107,7 @@ export const generateBlogContent = async (
 
   return {
     object,
-    usage: {
-      inputTokens: usage.inputTokens ?? 0,
-      outputTokens: usage.outputTokens ?? 0,
-      totalTokens: usage.totalTokens ?? 0,
-    },
+    usage,
     response: {
       id: response.id,
       modelId: response.modelId,

--- a/packages/ai/src/save-post.ts
+++ b/packages/ai/src/save-post.ts
@@ -1,12 +1,7 @@
 import { db, posts } from "@sgcarstrends/database";
 import { redis, slugify } from "@sgcarstrends/utils";
+import type { LanguageModelUsage } from "ai";
 import type { Highlight } from "./schemas";
-
-export interface TokenUsage {
-  inputTokens: number;
-  outputTokens: number;
-  totalTokens: number;
-}
 
 export interface PostParams {
   title: string;
@@ -21,7 +16,7 @@ export interface PostParams {
     responseId: string;
     modelId: string;
     timestamp: Date;
-    usage?: TokenUsage;
+    usage?: LanguageModelUsage;
   };
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,8 +7,8 @@ settings:
 catalogs:
   default:
     '@ai-sdk/google':
-      specifier: ^2.0.44
-      version: 2.0.51
+      specifier: ^3.0.0
+      version: 3.0.0
     '@langfuse/otel':
       specifier: ^4.4.2
       version: 4.5.1
@@ -37,8 +37,8 @@ catalogs:
       specifier: ^4.0.15
       version: 4.0.16
     ai:
-      specifier: ^5.0.105
-      version: 5.0.116
+      specifier: ^6.0.1
+      version: 6.0.1
     date-fns:
       specifier: ^3.6.0
       version: 3.6.0
@@ -143,7 +143,7 @@ importers:
     dependencies:
       '@ai-sdk/google':
         specifier: 'catalog:'
-        version: 2.0.51(zod@4.2.1)
+        version: 3.0.0(zod@4.2.1)
       '@better-auth/passkey':
         specifier: ^1.4.3
         version: 1.4.7(@better-auth/core@1.4.7(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.5(zod@4.2.1))(jose@6.1.3)(kysely@0.28.9)(nanostores@1.1.0))(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-auth@1.4.7(drizzle-kit@0.31.4)(drizzle-orm@0.44.3(@neondatabase/serverless@1.0.1)(@opentelemetry/api@1.9.0)(@types/pg@8.16.0)(@upstash/redis@1.35.8)(kysely@0.28.9))(next@16.1.0(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vitest@4.0.16))(better-call@1.1.5(zod@4.2.1))(nanostores@1.1.0)
@@ -173,7 +173,7 @@ importers:
         version: 1.0.0
       ai:
         specifier: 'catalog:'
-        version: 5.0.116(zod@4.2.1)
+        version: 6.0.1(zod@4.2.1)
       better-auth:
         specifier: ^1.4.5
         version: 1.4.7(drizzle-kit@0.31.4)(drizzle-orm@0.44.3(@neondatabase/serverless@1.0.1)(@opentelemetry/api@1.9.0)(@types/pg@8.16.0)(@upstash/redis@1.35.8)(kysely@0.28.9))(next@16.1.0(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vitest@4.0.16)
@@ -225,7 +225,7 @@ importers:
     dependencies:
       '@ai-sdk/google':
         specifier: 'catalog:'
-        version: 2.0.51(zod@4.2.1)
+        version: 3.0.0(zod@4.2.1)
       '@hono/zod-openapi':
         specifier: ^0.19.8
         version: 0.19.10(hono@4.11.1)(zod@4.2.1)
@@ -276,7 +276,7 @@ importers:
         version: 0.5.16
       ai:
         specifier: 'catalog:'
-        version: 5.0.116(zod@4.2.1)
+        version: 6.0.1(zod@4.2.1)
       date-fns:
         specifier: 'catalog:'
         version: 3.6.0
@@ -578,7 +578,7 @@ importers:
     dependencies:
       '@ai-sdk/google':
         specifier: 'catalog:'
-        version: 2.0.51(zod@4.2.1)
+        version: 3.0.0(zod@4.2.1)
       '@langfuse/otel':
         specifier: 'catalog:'
         version: 4.5.1(@opentelemetry/api@1.9.0)(@opentelemetry/core@2.2.0(@opentelemetry/api@1.9.0))(@opentelemetry/exporter-trace-otlp-http@0.208.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))
@@ -596,7 +596,7 @@ importers:
         version: 0.3.0-rc(zod@4.2.1)
       ai:
         specifier: 'catalog:'
-        version: 5.0.116(zod@4.2.1)
+        version: 6.0.1(zod@4.2.1)
       drizzle-orm:
         specifier: 0.44.3
         version: 0.44.3(@neondatabase/serverless@1.0.1)(@opentelemetry/api@1.9.0)(@types/pg@8.16.0)(@upstash/redis@1.35.8)(kysely@0.28.9)
@@ -758,26 +758,26 @@ packages:
   '@adobe/css-tools@4.4.4':
     resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
 
-  '@ai-sdk/gateway@2.0.23':
-    resolution: {integrity: sha512-qmX7afPRszUqG5hryHF3UN8ITPIRSGmDW6VYCmByzjoUkgm3MekzSx2hMV1wr0P+llDeuXb378SjqUfpvWJulg==}
+  '@ai-sdk/gateway@3.0.0':
+    resolution: {integrity: sha512-JcjePYVpbezv+XOxkxPemwnorjWpgDiiKWMYy6FXTCG2rFABIK2Co1bFxIUSDT4vYO6f1448x9rKbn38vbhDiA==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/google@2.0.51':
-    resolution: {integrity: sha512-5VMHdZTP4th00hthmh98jP+BZmxiTRMB9R2qh/AuF6OkQeiJikqxZg3hrWDfYrCmQ12wDjy6CbIypnhlwZiYrg==}
+  '@ai-sdk/google@3.0.0':
+    resolution: {integrity: sha512-KFS9pR7KGDyt7p1OQibglS3amoLjCXxwF7DVg+gL2RLcwFRQV0s6Tp7Q+PvGNFSqPdrPYW8mHyvn8ODK4WTImA==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/provider-utils@3.0.19':
-    resolution: {integrity: sha512-W41Wc9/jbUVXVwCN/7bWa4IKe8MtxO3EyA0Hfhx6grnmiYlCvpI8neSYWFE0zScXJkgA/YK3BRybzgyiXuu6JA==}
+  '@ai-sdk/provider-utils@4.0.0':
+    resolution: {integrity: sha512-HyCyOls9I3a3e38+gtvOJOEjuw9KRcvbBnCL5GBuSmJvS9Jh9v3fz7pRC6ha1EUo/ZH1zwvLWYXBMtic8MTguA==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/provider@2.0.0':
-    resolution: {integrity: sha512-6o7Y2SeO9vFKB8lArHXehNuusnpddKPk7xqL7T2/b+OvXMRIXUO1rR4wcv1hAFUAT9avGZshty3Wlua/XA7TvA==}
+  '@ai-sdk/provider@3.0.0':
+    resolution: {integrity: sha512-m9ka3ptkPQbaHHZHqDXDF9C9B5/Mav0KTdky1k2HZ3/nrW2t1AgObxIVPyGDWQNS9FXT/FS6PIoSjpcP/No8rQ==}
     engines: {node: '>=18'}
 
   '@alloc/quick-lru@5.2.0':
@@ -4615,8 +4615,8 @@ packages:
     resolution: {integrity: sha512-gOsf2YwSlleG6IjRYG2A7k0HmBMEo6qVNk9Bp/EaLgAJT5ngH6PXbqa4ItvnEwCm/velL5jAnQgsHsWnjhGmvw==}
     engines: {node: '>=18'}
 
-  ai@5.0.116:
-    resolution: {integrity: sha512-+2hYJ80/NcDWuv9K2/MLP3cTCFgwWHmHlS1tOpFUKKcmLbErAAlE/S2knsKboc3PNAu8pQkDr2N3K/Vle7ENgQ==}
+  ai@6.0.1:
+    resolution: {integrity: sha512-g/jPakC6h4vUJKDww0d6+VaJmfMC38UqH3kKsngiP+coT0uvCUdQ7lpFDJ0mNmamaOyRMaY2zwEB2RnTAaJU/w==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -8298,27 +8298,27 @@ snapshots:
 
   '@adobe/css-tools@4.4.4': {}
 
-  '@ai-sdk/gateway@2.0.23(zod@4.2.1)':
+  '@ai-sdk/gateway@3.0.0(zod@4.2.1)':
     dependencies:
-      '@ai-sdk/provider': 2.0.0
-      '@ai-sdk/provider-utils': 3.0.19(zod@4.2.1)
+      '@ai-sdk/provider': 3.0.0
+      '@ai-sdk/provider-utils': 4.0.0(zod@4.2.1)
       '@vercel/oidc': 3.0.5
       zod: 4.2.1
 
-  '@ai-sdk/google@2.0.51(zod@4.2.1)':
+  '@ai-sdk/google@3.0.0(zod@4.2.1)':
     dependencies:
-      '@ai-sdk/provider': 2.0.0
-      '@ai-sdk/provider-utils': 3.0.19(zod@4.2.1)
+      '@ai-sdk/provider': 3.0.0
+      '@ai-sdk/provider-utils': 4.0.0(zod@4.2.1)
       zod: 4.2.1
 
-  '@ai-sdk/provider-utils@3.0.19(zod@4.2.1)':
+  '@ai-sdk/provider-utils@4.0.0(zod@4.2.1)':
     dependencies:
-      '@ai-sdk/provider': 2.0.0
+      '@ai-sdk/provider': 3.0.0
       '@standard-schema/spec': 1.1.0
       eventsource-parser: 3.0.6
       zod: 4.2.1
 
-  '@ai-sdk/provider@2.0.0':
+  '@ai-sdk/provider@3.0.0':
     dependencies:
       json-schema: 0.4.0
 
@@ -12926,11 +12926,11 @@ snapshots:
       clean-stack: 5.3.0
       indent-string: 5.0.0
 
-  ai@5.0.116(zod@4.2.1):
+  ai@6.0.1(zod@4.2.1):
     dependencies:
-      '@ai-sdk/gateway': 2.0.23(zod@4.2.1)
-      '@ai-sdk/provider': 2.0.0
-      '@ai-sdk/provider-utils': 3.0.19(zod@4.2.1)
+      '@ai-sdk/gateway': 3.0.0(zod@4.2.1)
+      '@ai-sdk/provider': 3.0.0
+      '@ai-sdk/provider-utils': 4.0.0(zod@4.2.1)
       '@opentelemetry/api': 1.9.0
       zod: 4.2.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,7 +3,7 @@ packages:
   - packages/*
 
 catalog:
-  '@ai-sdk/google': ^2.0.44
+  '@ai-sdk/google': ^3.0.0
   '@langfuse/otel': ^4.4.2
   '@tailwindcss/postcss': ^4.1.11
   '@types/node': ^22.16.4
@@ -13,7 +13,7 @@ catalog:
   '@vercel/related-projects': ^1.0.0
   '@vitest/coverage-v8': ^4.0.15
   '@vitest/ui': ^4.0.15
-  ai: ^5.0.105
+  ai: ^6.0.1
   date-fns: ^3.6.0
   next: ^16.1.0
   react: ^19.2.3


### PR DESCRIPTION
- Upgraded to AI SDK v6 with `LanguageModelUsage` type and updated token property names (`inputTokens`, `outputTokens`)
- Compatible with Zod v4 directly (no `zod/v3` imports needed)