### PR TITLE
Fix missing sparklines on COE Overview page

### DIFF
--- a/apps/web/src/queries/coe/trends.ts
+++ b/apps/web/src/queries/coe/trends.ts
@@ -117,7 +117,7 @@ export const getAllCoeCategoryTrends = async (
     const latestMonth = await getLatestCoeMonth();
     if (!latestMonth) {
       return Object.fromEntries(
-        COE_CATEGORIES.map((category) => [category, []]),
+        COE_CATEGORIES.map((category) => [category, [] as CoeMonthlyPremium[]]),
       ) as Record<COECategory, CoeMonthlyPremium[]>;
     }
     ({ startMonth, endMonth } = getDateRangeRolling12Months(latestMonth));


### PR DESCRIPTION
- Uses rolling 12-month data from latest database month instead of current year-to-date
- Fixes sparklines not appearing when viewing page early in the year