### PR TITLE
Fix TypeScript type assertion for empty COE categories

### DIFF
--- a/apps/web/src/queries/coe/trends.ts
+++ b/apps/web/src/queries/coe/trends.ts
@@ -117,7 +117,7 @@ export async function getAllCoeCategoryTrends(
     const latestMonth = await getLatestCoeMonth();
     if (!latestMonth) {
       return Object.fromEntries(
-        COE_CATEGORIES.map((category) => [category, []]),
+        COE_CATEGORIES.map((category) => [category, [] as CoeMonthlyPremium[]]),
       ) as Record<COECategory, CoeMonthlyPremium[]>;
     }
     ({ startMonth, endMonth } = getDateRangeRolling12Months(latestMonth));


### PR DESCRIPTION
Add type assertion to fix build error for empty array return