### PR TITLE
Add PARF Calculator page and Budget 2026 documentation

### DIFF
--- a/apps/web/public/llm.txt
+++ b/apps/web/public/llm.txt
@@ -23,7 +23,7 @@ Singapore operates a unique vehicle quota system where prospective car owners mu
 - **COE**: Certificate of Entitlement - Required permit to own a vehicle
 - **LTA**: Land Transport Authority - Singapore's transport regulatory body
 - **ARF**: Additional Registration Fee - Tax based on vehicle's Open Market Value
-- **PARF**: Preferential Additional Registration Fee - Rebate for early vehicle disposal
+- **PARF**: Preferential Additional Registration Fee - Rebate for early vehicle deregistration, calculated as a percentage of ARF paid based on vehicle age. Budget 2026 reduced rates by 45 percentage points (e.g., 75% to 30% for vehicles 5 years and younger) and halved the cap from $60,000 to $30,000, effective from the 2nd COE bidding exercise in February 2026.
 - **OMV**: Open Market Value - Vehicle's market price excluding taxes
 - **PQP**: Prevailing Quota Premium - Price paid for COE in previous bidding exercise
 
@@ -124,4 +124,4 @@ Singapore's automotive market differs significantly from other Southeast Asian m
 
 This file provides comprehensive context for AI systems to understand Singapore's unique automotive market structure, the role of the COE system, and how SG Cars Trends serves as the authoritative source for related data and analysis.
 
-Last Updated: July 2024
+Last Updated: February 2026

--- a/apps/web/scripts/create-parf-blog-post.ts
+++ b/apps/web/scripts/create-parf-blog-post.ts
@@ -1,0 +1,145 @@
+/**
+ * One-off script to insert a blog post about the Budget 2026 PARF rebate changes.
+ *
+ * Usage:
+ *   DATABASE_URL="postgresql://..." npx tsx apps/web/scripts/create-parf-blog-post.ts
+ *
+ * Uses direct db.insert() instead of savePost() because the AI package
+ * constrains dataType to "cars" | "coe", and this post uses "policy".
+ */
+
+import { db, posts } from "@sgcarstrends/database";
+import { slugify } from "@sgcarstrends/utils";
+
+const title = "Budget 2026: What the PARF Rebate Changes Mean for Car Owners";
+const slug = slugify(title);
+
+const excerpt =
+  "Singapore Budget 2026 slashed PARF rebates by 45 percentage points and halved the cap from $60,000 to $30,000. Here's what changed and how it affects vehicle owners.";
+
+const content = `The Singapore Budget 2026, announced on 12 February 2026, introduced sweeping changes to the Preferential Additional Registration Fee (PARF) rebate system. These changes took effect from the 2nd COE bidding exercise in February 2026, marking the most significant overhaul of the PARF framework since its introduction.
+
+## What Changed
+
+The government reduced PARF rebate percentages by **45 percentage points** across every vehicle age bracket. At the same time, the maximum rebate cap was **halved from $60,000 to $30,000**.
+
+Here is a full comparison of the old and new rates:
+
+| Vehicle Age at Deregistration | Old Rate | New Rate | Change |
+|-------------------------------|----------|----------|--------|
+| 5 years or younger | 75% | 30% | -45pp |
+| More than 5 to 6 years | 70% | 25% | -45pp |
+| More than 6 to 7 years | 65% | 20% | -45pp |
+| More than 7 to 8 years | 60% | 15% | -45pp |
+| More than 8 to 9 years | 55% | 10% | -45pp |
+| More than 9 to 10 years | 50% | 5% | -45pp |
+| Over 10 years | 0% | 0% | — |
+
+## Impact on Car Owners
+
+The financial impact depends on the Additional Registration Fee (ARF) paid at registration and the vehicle's age at deregistration.
+
+**Example 1: Mid-range car (ARF $40,000, deregistered at 5 years)**
+- Old rebate: $30,000 (75% of $40,000)
+- New rebate: $12,000 (30% of $40,000)
+- **Difference: $18,000 less**
+
+**Example 2: Premium car (ARF $80,000, deregistered at 5 years)**
+- Old rebate: $60,000 (75% of $80,000, capped at $60,000)
+- New rebate: $24,000 (30% of $80,000)
+- **Difference: $36,000 less**
+
+**Example 3: Luxury car (ARF $150,000, deregistered at 7 years)**
+- Old rebate: $60,000 (65% of $150,000 = $97,500, capped at $60,000)
+- New rebate: $30,000 (20% of $150,000 = $30,000, at the new cap)
+- **Difference: $30,000 less**
+
+For vehicles with higher ARF values, the halved cap amplifies the reduction. Previously, a car with an ARF above $80,000 would hit the $60,000 ceiling. Under the new framework, the ceiling sits at $30,000 — meaning the effective rebate drops even further for expensive vehicles.
+
+## Why the Changes Were Made
+
+The government's rationale centres on the shift towards electric vehicles (EVs). As EVs produce zero tailpipe emissions, the original environmental justification for incentivising early vehicle deregistration has weakened. The PARF system was designed to encourage owners to scrap older, more pollutive vehicles — but with the fleet transitioning to cleaner powertrains, policymakers decided the generous rebate was no longer warranted.
+
+## What This Means Going Forward
+
+These changes apply to all vehicles registered with COEs obtained from the 2nd bidding exercise in February 2026 onwards. Vehicles registered before this date retain their eligibility under the old PARF schedule.
+
+For prospective car buyers, the reduced PARF rebate effectively increases the total cost of ownership over a 10-year COE cycle. Buyers should factor the lower rebate into their financial planning, especially for higher-ARF vehicles where the impact is most pronounced.
+
+We have added a [PARF Calculator](/cars/parf) tool to help you compare rebates under both the old and new rates. Enter your ARF amount and vehicle age to see exactly how the changes affect your situation.
+
+## Sources
+
+- [Revision of PARF Rebate Schedule and Cap — Land Transport Authority](https://www.lta.gov.sg/content/ltagov/en/newsroom/2026/2/news-releases/revision-parf-rebate-schedule-cap.html)
+- [Example of Application of Revised PARF Rebate Schedule and Cap (Annex A)](https://www.lta.gov.sg/content/dam/ltagov/news/press/2026/260212_eg-application-revised-PARF-rebate-schedule-cap-AnnexA.pdf)
+- [Budget 2026 — Ministry of Finance Singapore](https://www.mof.gov.sg/singaporebudget)`;
+
+const highlights = [
+  {
+    value: "-45pp",
+    label: "Rebate Rate Cut",
+    detail:
+      "All age brackets reduced by 45 percentage points (e.g. 75% to 30%)",
+  },
+  {
+    value: "$30,000",
+    label: "New Rebate Cap",
+    detail: "Halved from the previous cap of $60,000",
+  },
+  {
+    value: "30%",
+    label: "New Top Rate",
+    detail: "Maximum rebate for vehicles 5 years or younger, down from 75%",
+  },
+];
+
+const tags = ["Policy", "PARF", "Budget 2026", "Cars", "Electric Vehicles"];
+
+const heroImage =
+  "https://images.unsplash.com/photo-1519043916581-33ecfdba3b1c?w=1200&h=514&fit=crop";
+
+async function main() {
+  console.log(`Inserting blog post: "${title}"`);
+  console.log(`Slug: ${slug}`);
+  console.log(`DataType: policy, Month: 2026-02`);
+
+  const [post] = await db
+    .insert(posts)
+    .values({
+      title,
+      slug,
+      content,
+      excerpt,
+      heroImage,
+      tags,
+      highlights,
+      status: "published",
+      metadata: { source: "manual", reason: "Budget 2026 PARF changes" },
+      month: "2026-02",
+      dataType: "policy",
+      publishedAt: new Date(),
+    })
+    .onConflictDoUpdate({
+      target: [posts.month, posts.dataType],
+      set: {
+        title,
+        slug,
+        content,
+        excerpt,
+        heroImage,
+        tags,
+        highlights,
+        metadata: { source: "manual", reason: "Budget 2026 PARF changes" },
+        modifiedAt: new Date(),
+      },
+    })
+    .returning();
+
+  console.log(`Post saved — id: ${post.id}, slug: ${post.slug}`);
+  process.exit(0);
+}
+
+main().catch((error) => {
+  console.error("Failed to insert blog post:", error);
+  process.exit(1);
+});

--- a/apps/web/src/app/(main)/(dashboard)/cars/parf/components/about-parf.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/cars/parf/components/about-parf.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+// TODO: Migrate to HeroUI v3 Accordion when available
+import { Accordion, AccordionItem } from "@heroui/accordion";
+import { Info } from "lucide-react";
+import { Streamdown } from "streamdown";
+
+interface AboutParfProps {
+  title: string;
+  content: string;
+}
+
+export function AboutParf({ title, content }: AboutParfProps) {
+  return (
+    <Accordion
+      variant="shadow"
+      className="rounded-2xl bg-default-100 px-0"
+      itemClasses={{
+        base: "py-0",
+        title: "font-medium text-foreground",
+        trigger: "py-4 data-[hover=true]:bg-default-200 rounded-xl px-4",
+        content: "px-4 pb-4",
+      }}
+    >
+      <AccordionItem
+        key="context"
+        aria-label={title}
+        title={title}
+        startContent={<Info className="size-4 text-primary" />}
+      >
+        <div className="prose prose-sm max-w-none text-foreground">
+          <Streamdown>{content}</Streamdown>
+        </div>
+      </AccordionItem>
+    </Accordion>
+  );
+}

--- a/apps/web/src/app/(main)/(dashboard)/cars/parf/components/parf-calculator.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/cars/parf/components/parf-calculator.tsx
@@ -1,0 +1,201 @@
+"use client";
+
+import { Alert } from "@heroui/alert";
+import { Card, CardBody } from "@heroui/card";
+import { Divider } from "@heroui/divider";
+import { Input } from "@heroui/input";
+import { Select, SelectItem } from "@heroui/select";
+import { Currency } from "@web/components/shared/currency";
+import Typography from "@web/components/typography";
+import { ArrowDown } from "lucide-react";
+import { useMemo, useState } from "react";
+
+interface AgeBracket {
+  key: string;
+  label: string;
+  oldRate: number;
+  newRate: number;
+}
+
+const AGE_BRACKETS: AgeBracket[] = [
+  { key: "0", label: "5 years or younger", oldRate: 0.75, newRate: 0.3 },
+  { key: "1", label: "More than 5 to 6 years", oldRate: 0.7, newRate: 0.25 },
+  { key: "2", label: "More than 6 to 7 years", oldRate: 0.65, newRate: 0.2 },
+  { key: "3", label: "More than 7 to 8 years", oldRate: 0.6, newRate: 0.15 },
+  { key: "4", label: "More than 8 to 9 years", oldRate: 0.55, newRate: 0.1 },
+  { key: "5", label: "More than 9 to 10 years", oldRate: 0.5, newRate: 0.05 },
+  { key: "6", label: "Over 10 years", oldRate: 0, newRate: 0 },
+];
+
+const OLD_CAP = 60_000;
+const NEW_CAP = 30_000;
+
+export function PARFCalculator() {
+  const [arfInput, setArfInput] = useState("80000");
+  const [selectedBracket, setSelectedBracket] = useState("0");
+
+  const arf = Number(arfInput.replace(/[^0-9.]/g, "")) || 0;
+  const bracket = AGE_BRACKETS[Number(selectedBracket)] ?? AGE_BRACKETS[0];
+
+  const result = useMemo(() => {
+    const oldUncapped = arf * bracket.oldRate;
+    const newUncapped = arf * bracket.newRate;
+    const oldRebate = Math.min(oldUncapped, OLD_CAP);
+    const newRebate = Math.min(newUncapped, NEW_CAP);
+    const difference = oldRebate - newRebate;
+
+    return {
+      oldUncapped,
+      newUncapped,
+      oldRebate,
+      newRebate,
+      difference,
+      oldCapped: oldUncapped > OLD_CAP,
+      newCapped: newUncapped > NEW_CAP,
+    };
+  }, [arf, bracket]);
+
+  return (
+    <Card className="rounded-2xl">
+      <CardBody className="flex flex-col gap-6 p-6">
+        <Typography.H4>Calculate Your PARF Rebate</Typography.H4>
+
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+          <Input
+            label="ARF Amount Paid"
+            labelPlacement="outside"
+            placeholder="e.g. 40,000"
+            startContent={<span className="text-default-400 text-sm">$</span>}
+            type="text"
+            inputMode="numeric"
+            value={arfInput}
+            onValueChange={setArfInput}
+          />
+          <Select
+            label="Vehicle Age at Deregistration"
+            labelPlacement="outside"
+            selectedKeys={[selectedBracket]}
+            onSelectionChange={(keys) => {
+              const key = Array.from(keys)[0];
+              if (key !== undefined) setSelectedBracket(String(key));
+            }}
+          >
+            {AGE_BRACKETS.map(({ key, label }) => (
+              <SelectItem key={key}>{label}</SelectItem>
+            ))}
+          </Select>
+        </div>
+
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+          <Card className="rounded-2xl border border-default-200 bg-default-50 shadow-none">
+            <CardBody className="flex flex-col gap-4 p-6">
+              <div className="flex items-center gap-2">
+                <span className="size-2 rounded-full bg-default-400" />
+                <Typography.Caption className="font-semibold text-default-500 uppercase tracking-wider">
+                  Before Budget 2026
+                </Typography.Caption>
+              </div>
+              <div className="flex flex-col gap-2">
+                <Typography.Caption>PARF Rebate</Typography.Caption>
+                <span className="font-bold text-3xl text-default-600 tracking-tight">
+                  <Currency value={result.oldRebate} />
+                </span>
+              </div>
+              <Divider />
+              <div className="flex flex-col gap-2">
+                <div className="flex justify-between text-sm">
+                  <span className="text-default-500">Rebate Rate</span>
+                  <span className="font-medium">{bracket.oldRate * 100}%</span>
+                </div>
+                <div className="flex justify-between text-sm">
+                  <span className="text-default-500">Uncapped Amount</span>
+                  <span className="font-medium">
+                    <Currency value={result.oldUncapped} />
+                  </span>
+                </div>
+                <div className="flex justify-between text-sm">
+                  <span className="text-default-500">Cap</span>
+                  <span className="font-medium">
+                    <Currency value={OLD_CAP} />
+                  </span>
+                </div>
+              </div>
+              {result.oldCapped && (
+                <Typography.Caption className="text-warning">
+                  Cap of <Currency value={OLD_CAP} /> applied
+                </Typography.Caption>
+              )}
+            </CardBody>
+          </Card>
+
+          <Card className="rounded-2xl border border-primary-200 bg-primary-50 shadow-none">
+            <CardBody className="flex flex-col gap-4 p-6">
+              <div className="flex items-center gap-2">
+                <span className="size-2 rounded-full bg-primary" />
+                <Typography.Caption className="font-semibold text-primary uppercase tracking-wider">
+                  After Budget 2026
+                </Typography.Caption>
+              </div>
+              <div className="flex flex-col gap-2">
+                <Typography.Caption>PARF Rebate</Typography.Caption>
+                <span className="font-bold text-3xl text-primary tracking-tight">
+                  <Currency value={result.newRebate} />
+                </span>
+              </div>
+              <Divider />
+              <div className="flex flex-col gap-2">
+                <div className="flex justify-between text-sm">
+                  <span className="text-default-500">Rebate Rate</span>
+                  <span className="font-medium">{bracket.newRate * 100}%</span>
+                </div>
+                <div className="flex justify-between text-sm">
+                  <span className="text-default-500">Uncapped Amount</span>
+                  <span className="font-medium">
+                    <Currency value={result.newUncapped} />
+                  </span>
+                </div>
+                <div className="flex justify-between text-sm">
+                  <span className="text-default-500">Cap</span>
+                  <span className="font-medium">
+                    <Currency value={NEW_CAP} />
+                  </span>
+                </div>
+              </div>
+              {result.newCapped && (
+                <Typography.Caption className="text-warning">
+                  Cap of <Currency value={NEW_CAP} /> applied
+                </Typography.Caption>
+              )}
+            </CardBody>
+          </Card>
+        </div>
+
+        {result.difference > 0 && (
+          <Alert
+            color="danger"
+            variant="bordered"
+            icon={<ArrowDown className="size-4" />}
+            title={
+              <span>
+                You would receive{" "}
+                <strong>
+                  <Currency value={result.difference} /> less
+                </strong>{" "}
+                under the new Budget 2026 rates.
+              </span>
+            }
+          />
+        )}
+
+        {bracket.oldRate === 0 && (
+          <Alert
+            hideIconWrapper
+            color="default"
+            variant="bordered"
+            title="No PARF rebate is given for vehicles over 10 years old."
+          />
+        )}
+      </CardBody>
+    </Card>
+  );
+}

--- a/apps/web/src/app/(main)/(dashboard)/cars/parf/components/parf-comparison-table.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/cars/parf/components/parf-comparison-table.tsx
@@ -1,0 +1,87 @@
+import { Card, CardBody } from "@heroui/card";
+import Typography from "@web/components/typography";
+import { ArrowDown, Table } from "lucide-react";
+
+const BRACKETS = [
+  {
+    age: "5 years or younger",
+    oldRate: "75%",
+    newRate: "30%",
+    change: "-45pp",
+  },
+  { age: ">5 to 6 years", oldRate: "70%", newRate: "25%", change: "-45pp" },
+  { age: ">6 to 7 years", oldRate: "65%", newRate: "20%", change: "-45pp" },
+  { age: ">7 to 8 years", oldRate: "60%", newRate: "15%", change: "-45pp" },
+  { age: ">8 to 9 years", oldRate: "55%", newRate: "10%", change: "-45pp" },
+  { age: ">9 to 10 years", oldRate: "50%", newRate: "5%", change: "-45pp" },
+  { age: "Over 10 years", oldRate: "0%", newRate: "0%", change: null },
+];
+
+export function PARFComparisonTable() {
+  return (
+    <Card className="overflow-hidden rounded-2xl">
+      <CardBody className="flex flex-col gap-0 p-0">
+        <div className="flex items-center gap-2 px-6 py-4">
+          <Table className="size-4 text-primary" />
+          <Typography.H4>PARF Rebate Rate Comparison</Typography.H4>
+        </div>
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-default-200 border-y bg-default-50">
+                <th className="px-6 py-2 text-left font-semibold text-default-600 text-xs uppercase tracking-wider">
+                  Vehicle Age
+                </th>
+                <th className="px-6 py-2 text-center font-semibold text-default-600 text-xs uppercase tracking-wider">
+                  Old Rate
+                </th>
+                <th className="px-6 py-2 text-center font-semibold text-primary text-xs uppercase tracking-wider">
+                  New Rate
+                </th>
+                <th className="px-6 py-2 text-right font-semibold text-danger text-xs uppercase tracking-wider">
+                  Change
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {BRACKETS.map((row) => (
+                <tr
+                  key={row.age}
+                  className="border-default-100 border-b transition-colors last:border-b-0 hover:bg-default-50"
+                >
+                  <td className="px-6 py-2 font-medium">{row.age}</td>
+                  <td className="px-6 py-2 text-center text-default-500">
+                    {row.oldRate}
+                  </td>
+                  <td className="px-6 py-2 text-center font-semibold text-primary">
+                    {row.newRate}
+                  </td>
+                  <td className="px-6 py-2 text-right">
+                    {row.change ? (
+                      <span className="inline-flex items-center gap-1 font-semibold text-danger text-xs">
+                        <ArrowDown className="size-4" />
+                        {row.change}
+                      </span>
+                    ) : (
+                      <span className="text-default-400 text-xs">
+                        No change
+                      </span>
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+        <div className="flex flex-col justify-between gap-2 border-default-200 border-t bg-default-50 px-6 py-4 text-default-500 text-xs sm:flex-row">
+          <span>
+            Rebate Cap: <strong className="text-foreground">$60,000</strong>{" "}
+            (old) &rarr; <strong className="text-foreground">$30,000</strong>{" "}
+            (new)
+          </span>
+          <span>Effective: 2nd COE bidding, Feb 2026</span>
+        </div>
+      </CardBody>
+    </Card>
+  );
+}

--- a/apps/web/src/app/(main)/(dashboard)/cars/parf/page.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/cars/parf/page.tsx
@@ -54,7 +54,7 @@ export default function PARFCalculatorPage() {
         <PARFComparisonTable />
       </AnimatedSection>
       <AnimatedSection order={4}>
-        <p className="text-center text-default-400 text-xs">
+        <p className="text-center text-default-600 text-xs">
           Figures are for illustration only. The PARF rebate is subject to the
           vehicle&apos;s actual ARF paid and age at deregistration. New rates
           apply to vehicles registered with COEs obtained from the 2nd bidding

--- a/apps/web/src/app/(main)/(dashboard)/cars/parf/page.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/cars/parf/page.tsx
@@ -1,0 +1,75 @@
+import { AnimatedSection } from "@web/app/(main)/(dashboard)/components/animated-section";
+import { DashboardPageHeader } from "@web/components/dashboard-page-header";
+import { DashboardPageTitle } from "@web/components/dashboard-page-title";
+import { PAGE_CONTEXTS } from "@web/components/shared/page-contexts";
+import { StructuredData } from "@web/components/structured-data";
+import { SITE_URL } from "@web/config";
+import { createPageMetadata } from "@web/lib/metadata";
+import type { Metadata } from "next";
+import type { WebPage, WithContext } from "schema-dts";
+import { AboutParf } from "./components/about-parf";
+import { PARFCalculator } from "./components/parf-calculator";
+import { PARFComparisonTable } from "./components/parf-comparison-table";
+
+const title = "PARF Calculator";
+const description =
+  "Compare PARF rebates before and after the Budget 2026 changes. Calculate how much less you would receive under the new rates.";
+
+export const generateMetadata = (): Metadata => {
+  return createPageMetadata({
+    title,
+    description,
+    canonical: "/cars/parf",
+    images: `${SITE_URL}/opengraph-image.png`,
+  });
+};
+
+export default function PARFCalculatorPage() {
+  const structuredData: WithContext<WebPage> = {
+    "@context": "https://schema.org",
+    "@type": "WebPage",
+    name: title,
+    description,
+    url: `${SITE_URL}/cars/parf`,
+  };
+
+  return (
+    <div className="flex flex-col gap-4">
+      <StructuredData data={structuredData} />
+      <DashboardPageHeader
+        title={
+          <DashboardPageTitle
+            title="PARF Calculator"
+            subtitle="Compare PARF rebates before and after the Budget 2026 changes."
+          />
+        }
+      />
+      <AnimatedSection order={1}>
+        <AboutParf {...PAGE_CONTEXTS.parf} />
+      </AnimatedSection>
+      <AnimatedSection order={2}>
+        <PARFCalculator />
+      </AnimatedSection>
+      <AnimatedSection order={3}>
+        <PARFComparisonTable />
+      </AnimatedSection>
+      <AnimatedSection order={4}>
+        <p className="text-center text-default-400 text-xs">
+          Figures are for illustration only. The PARF rebate is subject to the
+          vehicle&apos;s actual ARF paid and age at deregistration. New rates
+          apply to vehicles registered with COEs obtained from the 2nd bidding
+          exercise in February 2026 onwards. Source:{" "}
+          <a
+            href="https://www.lta.gov.sg/content/ltagov/en/newsroom/2026/2/news-releases/revision-parf-rebate-schedule-cap.html"
+            className="text-primary underline"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            LTA
+          </a>
+          .
+        </p>
+      </AnimatedSection>
+    </div>
+  );
+}

--- a/apps/web/src/app/(main)/faq/page.tsx
+++ b/apps/web/src/app/(main)/faq/page.tsx
@@ -114,6 +114,26 @@ export default function FAQPage() {
       ],
     },
     {
+      title: "PARF and Vehicle Deregistration",
+      items: [
+        {
+          question: "What is PARF?",
+          answer:
+            "The Preferential Additional Registration Fee (PARF) is a rebate given when you deregister a vehicle before its COE expires. It is calculated as a percentage of the Additional Registration Fee (ARF) paid at registration, with the percentage decreasing as the vehicle ages. No PARF rebate is given for vehicles older than 10 years.",
+        },
+        {
+          question: "What changed with PARF in Budget 2026?",
+          answer:
+            "Budget 2026 reduced PARF rebate percentages by 45 percentage points across all vehicle age brackets. For example, vehicles aged 5 years or younger now receive 30% of ARF (down from 75%). The rebate cap was also halved from $60,000 to $30,000. These changes apply to vehicles registered with COEs obtained from the 2nd bidding exercise in February 2026 onwards.",
+        },
+        {
+          question: "How is the PARF rebate calculated?",
+          answer:
+            "The PARF rebate equals a percentage of the ARF you paid when registering the vehicle, based on the vehicle's age at deregistration. Under the new rates (effective Feb 2026): 30% for vehicles 5 years and younger, 25% for >5-6 years, 20% for >6-7 years, 15% for >7-8 years, 10% for >8-9 years, 5% for >9-10 years, and nil for vehicles over 10 years. The rebate is capped at $30,000.",
+        },
+      ],
+    },
+    {
       title: "Using SG Cars Trends",
       items: [
         {

--- a/apps/web/src/components/shared/page-contexts.ts
+++ b/apps/web/src/components/shared/page-contexts.ts
@@ -26,4 +26,10 @@ Data is sourced monthly from the **Land Transport Authority (LTA)**.`,
 
 It provides insights into fleet turnover and the impact of the 10-year COE lifecycle.`,
   },
+  parf: {
+    title: "What is PARF?",
+    content: `The **Preferential Additional Registration Fee (PARF)** rebate is given when you deregister a vehicle before its COE expires. The rebate is a percentage of the Additional Registration Fee (ARF) paid, decreasing as the vehicle ages.
+
+**Budget 2026 Changes (effective Feb 2026):** Rebate percentages cut by 45 percentage points across all brackets, and the cap halved from $60,000 to $30,000.`,
+  },
 } as const;

--- a/apps/web/src/config/navigation.ts
+++ b/apps/web/src/config/navigation.ts
@@ -128,6 +128,13 @@ export const navLinks: NavLinks = {
       description: "Analysis of saloons, hatchbacks, SUVs and more",
       iconColor: "text-purple-500",
     },
+    {
+      title: "PARF Calculator",
+      url: "/cars/parf",
+      icon: Calculator,
+      description: "Calculate PARF rebate under old and new rates",
+      badge: "new",
+    },
   ],
   coe: [
     {


### PR DESCRIPTION
## Summary
- Add interactive PARF calculator page at `/cars/parf` comparing old vs new rebate rates after Budget 2026 changes
- Add PARF FAQ section, update `llm.txt` with Budget 2026 context, and include blog post insertion script

Closes #684