### PR TITLE
Add registration stats and sparkline to popular makes cards

### DIFF
--- a/apps/web/src/app/(main)/(dashboard)/cars/components/makes/all-makes.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/cars/components/makes/all-makes.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type { Make } from "@web/types";
+import type { Make, MakeStats } from "@web/types";
 import { ChevronLeft, ChevronRight } from "lucide-react";
 import type { Key } from "react";
 import { useCallback, useRef, useState } from "react";
@@ -12,6 +12,7 @@ interface AllMakesProps {
   groupedMakes: Record<string, Make[]>;
   letters: string[];
   logoUrlMap?: Record<string, string>;
+  makeStatsMap?: Record<string, MakeStats>;
 }
 
 export function AllMakes({
@@ -20,6 +21,7 @@ export function AllMakes({
   groupedMakes,
   letters,
   logoUrlMap = {},
+  makeStatsMap,
 }: AllMakesProps) {
   const [selectedLetter, setSelectedLetter] = useState(letters[0]);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
@@ -109,7 +111,11 @@ export function AllMakes({
             {activeMakes.length} {activeMakes.length === 1 ? "make" : "makes"}
           </span>
         </div>
-        <MakeGrid makes={activeMakes} logoUrlMap={logoUrlMap} />
+        <MakeGrid
+          makes={activeMakes}
+          logoUrlMap={logoUrlMap}
+          makeStatsMap={makeStatsMap}
+        />
       </div>
     </section>
   );

--- a/apps/web/src/app/(main)/(dashboard)/cars/components/makes/make-card.test.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/cars/components/makes/make-card.test.tsx
@@ -22,4 +22,21 @@ describe("MakeCard", () => {
       screen.queryByRole("img", { name: `${mockMake} logo` }),
     ).not.toBeInTheDocument();
   });
+
+  it("should render registration count and market share when stats are provided", () => {
+    render(<MakeCard make={mockMake} count={1234} share={12.5} />);
+    expect(screen.getByText("1,234 regs")).toBeVisible();
+    expect(screen.getByText("12.5% share")).toBeVisible();
+  });
+
+  it("should not render stats when count and share are not provided", () => {
+    render(<MakeCard make={mockMake} />);
+    expect(screen.queryByText(/regs/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/share/)).not.toBeInTheDocument();
+  });
+
+  it("should not render stats when only count is provided", () => {
+    render(<MakeCard make={mockMake} count={1234} />);
+    expect(screen.queryByText(/regs/)).not.toBeInTheDocument();
+  });
 });

--- a/apps/web/src/app/(main)/(dashboard)/cars/components/makes/make-card.test.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/cars/components/makes/make-card.test.tsx
@@ -25,8 +25,9 @@ describe("MakeCard", () => {
 
   it("should render registration count and market share when stats are provided", () => {
     render(<MakeCard make={mockMake} count={1234} share={12.5} />);
-    expect(screen.getByText("1,234 regs")).toBeVisible();
-    expect(screen.getByText("12.5% share")).toBeVisible();
+    expect(screen.getByText("1,234")).toBeVisible();
+    expect(screen.getByText("regs")).toBeVisible();
+    expect(screen.getByText(/12\.5%/)).toBeVisible();
   });
 
   it("should not render stats when count and share are not provided", () => {

--- a/apps/web/src/app/(main)/(dashboard)/cars/components/makes/make-card.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/cars/components/makes/make-card.tsx
@@ -1,6 +1,8 @@
 import { Avatar } from "@heroui/avatar";
 import { Card, CardBody } from "@heroui/card";
-import { slugify } from "@sgcarstrends/utils";
+import { Chip } from "@heroui/chip";
+import { formatPercentage, slugify } from "@sgcarstrends/utils";
+import { Sparkline } from "@web/components/charts/sparkline";
 import Typography from "@web/components/typography";
 import type { Make } from "@web/types";
 import Image from "next/image";
@@ -9,40 +11,75 @@ import Link from "next/link";
 interface MakeCardProps {
   make: Make;
   logoUrl?: string;
+  count?: number;
+  share?: number;
+  trend?: { value: number }[];
 }
 
-export function MakeCard({ make, logoUrl }: MakeCardProps) {
+export function MakeCard({
+  make,
+  logoUrl,
+  count,
+  share,
+  trend,
+}: MakeCardProps) {
   const href = `/cars/makes/${slugify(make)}`;
+  const hasStats = count !== undefined && share !== undefined;
 
   return (
     <Card
       isPressable
       as={Link}
       href={href}
-      className="hover:-translate-y-1 p-3 transition-all duration-300 hover:shadow-lg"
+      className="p-3 transition-all duration-300 hover:-translate-y-1 hover:shadow-lg"
     >
       <CardBody>
         <div className="flex flex-col gap-2">
-          <div className="flex size-16 items-center justify-center">
-            {logoUrl ? (
-              <Image
-                alt={`${make} logo`}
-                src={logoUrl}
-                width={512}
-                height={512}
-                className="size-full object-contain"
-              />
-            ) : (
-              <Avatar
-                name={make.charAt(0) || "?"}
-                classNames={{
-                  base: "size-full bg-primary",
-                  name: "text-lg font-semibold text-primary-foreground",
-                }}
-              />
-            )}
+          <div className="flex items-center gap-2">
+            <div className="flex size-16 shrink-0 items-center justify-center">
+              {logoUrl ? (
+                <Image
+                  alt={`${make} logo`}
+                  src={logoUrl}
+                  width={512}
+                  height={512}
+                  className="size-full object-contain"
+                />
+              ) : (
+                <Avatar
+                  name={make.charAt(0) || "?"}
+                  classNames={{
+                    base: "size-full bg-primary",
+                    name: "text-lg font-semibold text-primary-foreground",
+                  }}
+                />
+              )}
+            </div>
+            <div className="flex min-w-0 flex-col gap-2">
+              <Typography.Label className="truncate">{make}</Typography.Label>
+              {hasStats && (
+                <div className="flex flex-col gap-2">
+                  <div className="flex items-baseline gap-2">
+                    <span className="font-bold text-xl tabular-nums leading-none">
+                      {count.toLocaleString()}
+                    </span>
+                    <Typography.Caption>regs</Typography.Caption>
+                  </div>
+                  <Chip
+                    color="primary"
+                    variant="flat"
+                    size="sm"
+                    className="w-fit rounded-full"
+                  >
+                    {formatPercentage(share)} share
+                  </Chip>
+                </div>
+              )}
+            </div>
           </div>
-          <Typography.Label>{make}</Typography.Label>
+          {trend && trend.length > 0 && (
+            <Sparkline data={trend} height="h-10" />
+          )}
         </div>
       </CardBody>
     </Card>

--- a/apps/web/src/app/(main)/(dashboard)/cars/components/makes/make-grid.test.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/cars/components/makes/make-grid.test.tsx
@@ -25,4 +25,22 @@ describe("MakeGrid", () => {
     render(<MakeGrid makes={[]} />);
     expect(screen.queryByRole("link")).not.toBeInTheDocument();
   });
+
+  it("should pass stats to MakeCard when makeStatsMap is provided", () => {
+    const makeStatsMap = {
+      BMW: {
+        count: 1234,
+        share: 12.5,
+        trend: [{ value: 100 }, { value: 120 }],
+      },
+    };
+    render(<MakeGrid makes={germanMakes} makeStatsMap={makeStatsMap} />);
+    expect(screen.getByText("1,234 regs")).toBeVisible();
+    expect(screen.getByText("12.5% share")).toBeVisible();
+  });
+
+  it("should render without stats when makeStatsMap is not provided", () => {
+    render(<MakeGrid makes={germanMakes} />);
+    expect(screen.queryByText(/regs/)).not.toBeInTheDocument();
+  });
 });

--- a/apps/web/src/app/(main)/(dashboard)/cars/components/makes/make-grid.test.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/cars/components/makes/make-grid.test.tsx
@@ -35,8 +35,9 @@ describe("MakeGrid", () => {
       },
     };
     render(<MakeGrid makes={germanMakes} makeStatsMap={makeStatsMap} />);
-    expect(screen.getByText("1,234 regs")).toBeVisible();
-    expect(screen.getByText("12.5% share")).toBeVisible();
+    expect(screen.getByText("1,234")).toBeVisible();
+    expect(screen.getByText("regs")).toBeVisible();
+    expect(screen.getByText(/12\.5%/)).toBeVisible();
   });
 
   it("should render without stats when makeStatsMap is not provided", () => {

--- a/apps/web/src/app/(main)/(dashboard)/cars/components/makes/make-grid.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/cars/components/makes/make-grid.tsx
@@ -1,21 +1,30 @@
 import { slugify } from "@sgcarstrends/utils";
-import type { Make } from "@web/types";
+import type { Make, MakeStats } from "@web/types";
 import { MakeCard } from "./make-card";
 
 interface MakeGridProps {
   makes: Make[];
   logoUrlMap?: Record<string, string>;
+  makeStatsMap?: Record<string, MakeStats>;
 }
 
-export function MakeGrid({ makes, logoUrlMap = {} }: MakeGridProps) {
+export function MakeGrid({
+  makes,
+  logoUrlMap = {},
+  makeStatsMap,
+}: MakeGridProps) {
   return (
     <div className="grid grid-cols-2 gap-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6">
       {makes.map((make) => {
+        const stats = makeStatsMap?.[make];
         return (
           <MakeCard
             key={make}
             make={make}
             logoUrl={logoUrlMap[slugify(make)]}
+            count={stats?.count}
+            share={stats?.share}
+            trend={stats?.trend}
           />
         );
       })}

--- a/apps/web/src/app/(main)/(dashboard)/cars/components/makes/makes-dashboard.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/cars/components/makes/makes-dashboard.tsx
@@ -7,7 +7,7 @@ import {
   MakeSearch,
   PopularMakes,
 } from "@web/app/(main)/(dashboard)/cars/components/makes";
-import type { Make } from "@web/types";
+import type { Make, MakeStats } from "@web/types";
 import { useMemo } from "react";
 
 interface MakesDashboardProps {
@@ -16,6 +16,7 @@ interface MakesDashboardProps {
   letters: string[];
   popularMakes: Make[];
   logos?: CarLogo[] | null;
+  makeStatsMap?: Record<string, MakeStats>;
 }
 
 export function MakesDashboard({
@@ -24,6 +25,7 @@ export function MakesDashboard({
   letters,
   popularMakes,
   logos = [],
+  makeStatsMap,
 }: MakesDashboardProps) {
   const logoUrlMap = useMemo(() => {
     return (
@@ -39,7 +41,11 @@ export function MakesDashboard({
   return (
     <div className="flex flex-col gap-4">
       <MakeSearch makes={sortedMakes} />
-      <PopularMakes makes={popularMakes} logoUrlMap={logoUrlMap} />
+      <PopularMakes
+        makes={popularMakes}
+        logoUrlMap={logoUrlMap}
+        makeStatsMap={makeStatsMap}
+      />
       <AllMakes
         title="All Makes"
         sortedMakes={sortedMakes}

--- a/apps/web/src/app/(main)/(dashboard)/cars/components/makes/popular-makes.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/cars/components/makes/popular-makes.tsx
@@ -1,13 +1,19 @@
-import type { Make } from "@web/types";
+import { slugify } from "@sgcarstrends/utils";
+import type { Make, MakeStats } from "@web/types";
 import { Flame } from "lucide-react";
-import { MakeGrid } from "./make-grid";
+import { MakeCard } from "./make-card";
 
 interface PopularMakesProps {
   makes: Make[];
   logoUrlMap?: Record<string, string>;
+  makeStatsMap?: Record<string, MakeStats>;
 }
 
-export function PopularMakes({ makes, logoUrlMap = {} }: PopularMakesProps) {
+export function PopularMakes({
+  makes,
+  logoUrlMap = {},
+  makeStatsMap,
+}: PopularMakesProps) {
   if (makes.length === 0) {
     return null;
   }
@@ -27,7 +33,21 @@ export function PopularMakes({ makes, logoUrlMap = {} }: PopularMakesProps) {
           Top {makes.length}
         </span>
       </div>
-      <MakeGrid makes={makes} logoUrlMap={logoUrlMap} />
+      <div className="grid grid-cols-2 gap-2 md:grid-cols-4">
+        {makes.map((make) => {
+          const stats = makeStatsMap?.[make];
+          return (
+            <MakeCard
+              key={make}
+              make={make}
+              logoUrl={logoUrlMap[slugify(make)]}
+              count={stats?.count}
+              share={stats?.share}
+              trend={stats?.trend}
+            />
+          );
+        })}
+      </div>
     </section>
   );
 }

--- a/apps/web/src/app/(main)/(dashboard)/cars/components/makes/popular-makes.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/cars/components/makes/popular-makes.tsx
@@ -1,6 +1,6 @@
 import { slugify } from "@sgcarstrends/utils";
 import type { Make, MakeStats } from "@web/types";
-import { Flame } from "lucide-react";
+import { TrendingUp } from "lucide-react";
 import { MakeCard } from "./make-card";
 
 interface PopularMakesProps {
@@ -22,14 +22,14 @@ export function PopularMakes({
     <section className="flex flex-col gap-6">
       <div className="flex items-center gap-4">
         <div className="flex items-center gap-2">
-          <div className="flex size-7 items-center justify-center rounded-lg bg-gradient-to-br from-amber-400 to-orange-500">
-            <Flame className="size-4 text-white" />
+          <div className="flex size-7 items-center justify-center rounded-lg bg-primary">
+            <TrendingUp className="size-4 text-primary-foreground" />
           </div>
           <h2 className="font-semibold text-foreground text-lg">
             Popular Makes
           </h2>
         </div>
-        <span className="rounded-full bg-amber-500/10 px-2.5 py-0.5 font-medium text-amber-600 text-xs">
+        <span className="rounded-full bg-primary/10 px-2.5 py-0.5 font-medium text-primary text-xs">
           Top {makes.length}
         </span>
       </div>

--- a/apps/web/src/queries/cars/makes/index.ts
+++ b/apps/web/src/queries/cars/makes/index.ts
@@ -3,3 +3,4 @@ export * from "./entity-breakdowns";
 export * from "./entity-checks";
 export * from "./get-make-from-slug";
 export * from "./grouped-makes";
+export * from "./registration-stats";

--- a/apps/web/src/queries/cars/makes/registration-stats.ts
+++ b/apps/web/src/queries/cars/makes/registration-stats.ts
@@ -1,0 +1,82 @@
+import { asc, cars, db, max, sql } from "@sgcarstrends/database";
+import { cacheLife, cacheTag } from "next/cache";
+
+export interface MakeRegistrationStat {
+  make: string;
+  count: number;
+  share: number;
+  trend: { value: number }[];
+}
+
+/**
+ * Get registration count, market share, and rolling 12-month trend per make.
+ */
+export async function getMakeRegistrationStats(): Promise<
+  MakeRegistrationStat[]
+> {
+  "use cache";
+  cacheLife("max");
+  cacheTag("cars:makes");
+
+  const [latestMonthResult] = await db
+    .select({ latestMonth: max(cars.month) })
+    .from(cars);
+
+  const latestMonth = latestMonthResult?.latestMonth;
+  if (!latestMonth) {
+    return [];
+  }
+
+  const year = latestMonth.split("-")[0];
+
+  // Annual totals for the latest year (for count + share)
+  const annualRows = await db
+    .select({
+      make: cars.make,
+      count: sql<number>`cast(sum(${cars.number}) as int)`,
+    })
+    .from(cars)
+    .where(
+      sql`${cars.month} >= ${`${year}-01`} and ${cars.month} <= ${`${year}-12`}`,
+    )
+    .groupBy(cars.make);
+
+  const grandTotal = annualRows.reduce((sum, row) => sum + row.count, 0);
+
+  // Compute the 12-month cutoff in JS to avoid Postgres date casting issues
+  // with YYYY-MM strings (which are not valid date literals without a day).
+  const [latestYear, latestMonthNum] = latestMonth.split("-").map(Number);
+  const cutoffDate = new Date(latestYear, latestMonthNum - 1 - 12);
+  const cutoffMonth = `${cutoffDate.getFullYear()}-${String(cutoffDate.getMonth() + 1).padStart(2, "0")}`;
+
+  // Rolling 12-month monthly data (for sparkline trend)
+  const monthlyRows = await db
+    .select({
+      make: cars.make,
+      month: cars.month,
+      count: sql<number>`cast(sum(${cars.number}) as int)`,
+    })
+    .from(cars)
+    .where(
+      sql`${cars.month} > ${cutoffMonth} and ${cars.month} <= ${latestMonth}`,
+    )
+    .groupBy(cars.make, cars.month)
+    .orderBy(asc(cars.month));
+
+  // Group monthly rows by make
+  const trendByMake = monthlyRows.reduce<Record<string, { value: number }[]>>(
+    (acc, row) => {
+      if (!acc[row.make]) acc[row.make] = [];
+      acc[row.make].push({ value: row.count });
+      return acc;
+    },
+    {},
+  );
+
+  return annualRows.map((row) => ({
+    make: row.make,
+    count: row.count,
+    share: grandTotal > 0 ? (row.count / grandTotal) * 100 : 0,
+    trend: trendByMake[row.make] ?? [],
+  }));
+}

--- a/apps/web/src/types/index.ts
+++ b/apps/web/src/types/index.ts
@@ -1,5 +1,4 @@
 import type { COECategory, VehicleType } from "@sgcarstrends/types";
-import type { FUEL_TYPE } from "@web/config";
 import type { LucideIcon } from "lucide-react";
 
 export type { COECategory, VehicleType };
@@ -62,6 +61,12 @@ export enum RevalidateTags {
 }
 
 export type Make = string;
+
+export interface MakeStats {
+  count: number;
+  share: number;
+  trend: { value: number }[];
+}
 
 export type Month = string;
 


### PR DESCRIPTION
- Add `getMakeRegistrationStats` query returning annual count, market share %, and rolling 12-month trend per make
- Display bold registration count, primary-coloured share chip, and sparkline on Popular Makes cards; replace Flame icon with TrendingUp

Closes #453