### PR TITLE
Add YoY growth chips and header summary to makes page

### DIFF
--- a/apps/web/src/app/(main)/(dashboard)/cars/components/makes/index.ts
+++ b/apps/web/src/app/(main)/(dashboard)/cars/components/makes/index.ts
@@ -6,4 +6,5 @@ export { MakeGrid } from "./make-grid";
 export { MakeSearch } from "./make-search";
 export { MakeTrendChart } from "./make-trend-chart";
 export { MakesDashboard } from "./makes-dashboard";
+export { MakesSummary } from "./makes-summary";
 export { PopularMakes } from "./popular-makes";

--- a/apps/web/src/app/(main)/(dashboard)/cars/components/makes/make-card.test.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/cars/components/makes/make-card.test.tsx
@@ -40,4 +40,30 @@ describe("MakeCard", () => {
     render(<MakeCard make={mockMake} count={1234} />);
     expect(screen.queryByText(/regs/)).not.toBeInTheDocument();
   });
+
+  it("should render positive YoY growth chip when yoyChange is positive", () => {
+    render(
+      <MakeCard make={mockMake} count={1234} share={12.5} yoyChange={8.3} />,
+    );
+    expect(screen.getByText("+8.3%")).toBeVisible();
+  });
+
+  it("should render negative YoY growth chip when yoyChange is negative", () => {
+    render(
+      <MakeCard make={mockMake} count={1234} share={12.5} yoyChange={-5.2} />,
+    );
+    expect(screen.getByText("-5.2%")).toBeVisible();
+  });
+
+  it("should not render YoY growth chip when yoyChange is null", () => {
+    render(
+      <MakeCard make={mockMake} count={1234} share={12.5} yoyChange={null} />,
+    );
+    expect(screen.queryByText(/[+-]\d+\.\d+%/)).not.toBeInTheDocument();
+  });
+
+  it("should not render YoY growth chip when yoyChange is not provided", () => {
+    render(<MakeCard make={mockMake} count={1234} share={12.5} />);
+    expect(screen.queryByText(/[+-]\d+\.\d+%/)).not.toBeInTheDocument();
+  });
 });

--- a/apps/web/src/app/(main)/(dashboard)/cars/components/makes/make-card.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/cars/components/makes/make-card.tsx
@@ -1,10 +1,15 @@
 import { Avatar } from "@heroui/avatar";
 import { Card, CardBody } from "@heroui/card";
 import { Chip } from "@heroui/chip";
-import { formatPercentage, slugify } from "@sgcarstrends/utils";
+import {
+  formatGrowthRate,
+  formatPercentage,
+  slugify,
+} from "@sgcarstrends/utils";
 import { Sparkline } from "@web/components/charts/sparkline";
 import Typography from "@web/components/typography";
 import type { Make } from "@web/types";
+import { TrendingDown, TrendingUp } from "lucide-react";
 import Image from "next/image";
 import Link from "next/link";
 
@@ -14,6 +19,7 @@ interface MakeCardProps {
   count?: number;
   share?: number;
   trend?: { value: number }[];
+  yoyChange?: number | null;
 }
 
 export function MakeCard({
@@ -22,9 +28,9 @@ export function MakeCard({
   count,
   share,
   trend,
+  yoyChange,
 }: MakeCardProps) {
   const href = `/cars/makes/${slugify(make)}`;
-  const hasStats = count !== undefined && share !== undefined;
 
   return (
     <Card
@@ -35,7 +41,7 @@ export function MakeCard({
     >
       <CardBody>
         <div className="flex flex-col gap-2">
-          <div className="flex items-center gap-2">
+          <div className="flex items-start gap-2">
             <div className="flex size-16 shrink-0 items-center justify-center">
               {logoUrl ? (
                 <Image
@@ -57,7 +63,7 @@ export function MakeCard({
             </div>
             <div className="flex min-w-0 flex-col gap-2">
               <Typography.Label className="truncate">{make}</Typography.Label>
-              {hasStats && (
+              {count && share && (
                 <div className="flex flex-col gap-2">
                   <div className="flex items-baseline gap-2">
                     <span className="font-bold text-xl tabular-nums leading-none">
@@ -65,14 +71,32 @@ export function MakeCard({
                     </span>
                     <Typography.Caption>regs</Typography.Caption>
                   </div>
-                  <Chip
-                    color="primary"
-                    variant="flat"
-                    size="sm"
-                    className="w-fit rounded-full"
-                  >
-                    {formatPercentage(share)} share
-                  </Chip>
+                  <div className="flex flex-wrap items-center gap-2">
+                    <Chip
+                      color="primary"
+                      variant="flat"
+                      size="sm"
+                      className="rounded-full"
+                    >
+                      {formatPercentage(share)} share
+                    </Chip>
+                    {yoyChange && (
+                      <Chip
+                        color={yoyChange >= 0 ? "success" : "danger"}
+                        variant="flat"
+                        size="sm"
+                        startContent={
+                          yoyChange >= 0 ? (
+                            <TrendingUp className="size-3" />
+                          ) : (
+                            <TrendingDown className="size-3" />
+                          )
+                        }
+                      >
+                        {formatGrowthRate(yoyChange)}
+                      </Chip>
+                    )}
+                  </div>
                 </div>
               )}
             </div>

--- a/apps/web/src/app/(main)/(dashboard)/cars/components/makes/make-grid.test.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/cars/components/makes/make-grid.test.tsx
@@ -32,6 +32,7 @@ describe("MakeGrid", () => {
         count: 1234,
         share: 12.5,
         trend: [{ value: 100 }, { value: 120 }],
+        yoyChange: 8.3,
       },
     };
     render(<MakeGrid makes={germanMakes} makeStatsMap={makeStatsMap} />);

--- a/apps/web/src/app/(main)/(dashboard)/cars/components/makes/make-grid.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/cars/components/makes/make-grid.tsx
@@ -25,6 +25,7 @@ export function MakeGrid({
             count={stats?.count}
             share={stats?.share}
             trend={stats?.trend}
+            yoyChange={stats?.yoyChange}
           />
         );
       })}

--- a/apps/web/src/app/(main)/(dashboard)/cars/components/makes/makes-dashboard.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/cars/components/makes/makes-dashboard.tsx
@@ -5,9 +5,14 @@ import { slugify } from "@sgcarstrends/utils";
 import {
   AllMakes,
   MakeSearch,
+  MakesSummary,
   PopularMakes,
 } from "@web/app/(main)/(dashboard)/cars/components/makes";
-import type { Make, MakeStats } from "@web/types";
+import type {
+  Make,
+  MakeStats,
+  MakesSummary as MakesSummaryType,
+} from "@web/types";
 import { useMemo } from "react";
 
 interface MakesDashboardProps {
@@ -17,6 +22,7 @@ interface MakesDashboardProps {
   popularMakes: Make[];
   logos?: CarLogo[] | null;
   makeStatsMap?: Record<string, MakeStats>;
+  makesSummary?: MakesSummaryType;
 }
 
 export function MakesDashboard({
@@ -26,6 +32,7 @@ export function MakesDashboard({
   popularMakes,
   logos = [],
   makeStatsMap,
+  makesSummary,
 }: MakesDashboardProps) {
   const logoUrlMap = useMemo(() => {
     return (
@@ -40,6 +47,7 @@ export function MakesDashboard({
 
   return (
     <div className="flex flex-col gap-4">
+      {makesSummary && <MakesSummary summary={makesSummary} />}
       <MakeSearch makes={sortedMakes} />
       <PopularMakes
         makes={popularMakes}

--- a/apps/web/src/app/(main)/(dashboard)/cars/components/makes/makes-summary.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/cars/components/makes/makes-summary.tsx
@@ -1,0 +1,31 @@
+import Typography from "@web/components/typography";
+import type { MakesSummary as MakesSummaryType } from "@web/types";
+
+interface MakesSummaryProps {
+  summary: MakesSummaryType;
+}
+
+export function MakesSummary({ summary }: MakesSummaryProps) {
+  return (
+    <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+      <div className="flex flex-col gap-2 rounded-2xl bg-default-100 p-4">
+        <Typography.Caption>Total Makes</Typography.Caption>
+        <span className="font-bold text-2xl text-primary tabular-nums">
+          {summary.totalMakes.toLocaleString()}
+        </span>
+      </div>
+      <div className="flex flex-col gap-2 rounded-2xl bg-default-100 p-4">
+        <Typography.Caption>Total Registrations</Typography.Caption>
+        <span className="font-bold text-2xl text-primary tabular-nums">
+          {summary.totalRegistrations.toLocaleString()}
+        </span>
+      </div>
+      <div className="flex flex-col gap-2 rounded-2xl bg-default-100 p-4">
+        <Typography.Caption>Market Leader</Typography.Caption>
+        <span className="font-bold text-2xl text-primary">
+          {summary.marketLeader}
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/(main)/(dashboard)/cars/components/makes/popular-makes.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/cars/components/makes/popular-makes.tsx
@@ -44,6 +44,7 @@ export function PopularMakes({
               count={stats?.count}
               share={stats?.share}
               trend={stats?.trend}
+              yoyChange={stats?.yoyChange}
             />
           );
         })}

--- a/apps/web/src/app/(main)/(dashboard)/cars/makes/components/makes-content-section.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/cars/makes/components/makes-content-section.tsx
@@ -9,7 +9,7 @@ import {
   getGroupedMakes,
   getMakeRegistrationStats,
 } from "@web/queries/cars/makes";
-import type { MakeStats } from "@web/types";
+import type { MakeStats, MakesSummary } from "@web/types";
 import { Suspense } from "react";
 import type { WebPage, WithContext } from "schema-dts";
 
@@ -29,12 +29,26 @@ async function CarMakesContent() {
   const popular = popularMakes.map((item) => item.make);
 
   const makeStatsMap = statsArray.reduce<Record<string, MakeStats>>(
-    (acc, { make, count, share, trend }) => {
-      acc[make] = { count, share, trend };
+    (acc, { make, count, share, trend, yoyChange }) => {
+      acc[make] = { count, share, trend, yoyChange };
       return acc;
     },
     {},
   );
+
+  const totalRegistrations = statsArray.reduce(
+    (sum, { count }) => sum + count,
+    0,
+  );
+  const marketLeader = statsArray.reduce(
+    (top, row) => (row.count > top.count ? row : top),
+    statsArray[0] ?? { make: "", count: 0 },
+  );
+  const makesSummary: MakesSummary = {
+    totalMakes: statsArray.length,
+    totalRegistrations,
+    marketLeader: marketLeader.make,
+  };
 
   const structuredData: WithContext<WebPage> = {
     "@context": "https://schema.org",
@@ -59,6 +73,7 @@ async function CarMakesContent() {
         popularMakes={popular}
         logos={logos}
         makeStatsMap={makeStatsMap}
+        makesSummary={makesSummary}
       />
     </>
   );

--- a/apps/web/src/types/index.ts
+++ b/apps/web/src/types/index.ts
@@ -66,6 +66,13 @@ export interface MakeStats {
   count: number;
   share: number;
   trend: { value: number }[];
+  yoyChange: number | null;
+}
+
+export interface MakesSummary {
+  totalMakes: number;
+  totalRegistrations: number;
+  marketLeader: string;
 }
 
 export type Month = string;


### PR DESCRIPTION
- Add year-over-year growth chip (success/danger) alongside share chip on Popular Makes cards, computed from a previous-year annual query
- Add header summary bar above the makes grid showing total makes, total registrations, and market leader