### PR TITLE
Add fuel and vehicle type breakdown charts to make detail page

### DIFF
--- a/apps/web/src/app/(main)/(dashboard)/cars/components/makes/index.ts
+++ b/apps/web/src/app/(main)/(dashboard)/cars/components/makes/index.ts
@@ -8,3 +8,4 @@ export { MakeTrendChart } from "./make-trend-chart";
 export { MakesDashboard } from "./makes-dashboard";
 export { MakesSummary } from "./makes-summary";
 export { PopularMakes } from "./popular-makes";
+export { TypeBreakdownChart } from "./type-breakdown-chart";

--- a/apps/web/src/app/(main)/(dashboard)/cars/components/makes/make-detail.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/cars/components/makes/make-detail.tsx
@@ -6,6 +6,7 @@ import { DataTable } from "@sgcarstrends/ui/components/data-table";
 import {
   CoeComparisonChart,
   MakeTrendChart,
+  TypeBreakdownChart,
 } from "@web/app/(main)/(dashboard)/cars/components/makes";
 import { EmptyState } from "@web/components/shared/empty-state";
 import { columns } from "@web/components/tables/columns/cars-make-columns";
@@ -18,9 +19,17 @@ interface MakeDetailProps {
   cars: { make: string; total: number; data: Partial<SelectCar>[] } | null;
   coeComparison: MakeCoeComparisonData[];
   logo?: CarLogo | null;
+  fuelTypeBreakdown?: { name: string; value: number }[];
+  vehicleTypeBreakdown?: { name: string; value: number }[];
 }
 
-export function MakeDetail({ cars, coeComparison, logo }: MakeDetailProps) {
+export function MakeDetail({
+  cars,
+  coeComparison,
+  logo,
+  fuelTypeBreakdown = [],
+  vehicleTypeBreakdown = [],
+}: MakeDetailProps) {
   if (!cars) {
     return <EmptyState />;
   }
@@ -102,6 +111,26 @@ export function MakeDetail({ cars, coeComparison, logo }: MakeDetailProps) {
           <MakeTrendChart data={cars.data.toReversed()} />
         </CardBody>
       </Card>
+
+      {/* Fuel & Vehicle Type Breakdown Charts */}
+      {(fuelTypeBreakdown.length > 0 || vehicleTypeBreakdown.length > 0) && (
+        <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
+          {fuelTypeBreakdown.length > 0 && (
+            <TypeBreakdownChart
+              data={fuelTypeBreakdown}
+              title="Fuel Type Breakdown"
+              description="Registrations by fuel type"
+            />
+          )}
+          {vehicleTypeBreakdown.length > 0 && (
+            <TypeBreakdownChart
+              data={vehicleTypeBreakdown}
+              title="Vehicle Type Breakdown"
+              description="Registrations by vehicle type"
+            />
+          )}
+        </div>
+      )}
 
       {/* COE Comparison Chart */}
       <Card className="rounded-2xl p-3">

--- a/apps/web/src/app/(main)/(dashboard)/cars/components/makes/type-breakdown-chart.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/cars/components/makes/type-breakdown-chart.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { Card, CardBody, CardHeader } from "@heroui/card";
+import {
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+} from "@sgcarstrends/ui/components/chart";
+import Typography from "@web/components/typography";
+import { formatNumber } from "@web/utils/charts";
+import { Bar, BarChart, CartesianGrid, Cell, XAxis, YAxis } from "recharts";
+
+interface TypeBreakdownChartProps {
+  data: { name: string; value: number }[];
+  title: string;
+  description?: string;
+}
+
+export function TypeBreakdownChart({
+  data,
+  title,
+  description,
+}: TypeBreakdownChartProps) {
+  const chartData = data.map((item, index) => ({
+    ...item,
+    fill: `var(--chart-${Math.min(index + 1, 6)})`,
+  }));
+
+  const chartConfig = Object.fromEntries(
+    data.map((item, index) => [
+      item.name,
+      { label: item.name, color: `var(--chart-${Math.min(index + 1, 6)})` },
+    ]),
+  );
+
+  return (
+    <Card className="rounded-2xl p-3">
+      <CardHeader className="flex flex-col items-start gap-2">
+        <Typography.H4>{title}</Typography.H4>
+        {description && <Typography.TextSm>{description}</Typography.TextSm>}
+      </CardHeader>
+      <CardBody>
+        <ChartContainer config={chartConfig} className="h-[200px] w-full">
+          <BarChart data={chartData} layout="vertical">
+            <CartesianGrid
+              horizontal={false}
+              strokeDasharray="3 3"
+              className="stroke-default-200"
+            />
+            <XAxis
+              type="number"
+              tickFormatter={formatNumber}
+              tickLine={false}
+              axisLine={false}
+            />
+            <YAxis
+              type="category"
+              dataKey="name"
+              tickLine={false}
+              axisLine={false}
+              width={100}
+            />
+            <ChartTooltip
+              cursor={{ fill: "hsl(var(--muted))", opacity: 0.2 }}
+              content={<ChartTooltipContent />}
+            />
+            <Bar dataKey="value" radius={[0, 4, 4, 0]}>
+              {chartData.map((entry) => (
+                <Cell key={`cell-${entry.name}`} fill={entry.fill} />
+              ))}
+            </Bar>
+          </BarChart>
+        </ChartContainer>
+      </CardBody>
+    </Card>
+  );
+}

--- a/apps/web/src/app/(main)/(dashboard)/cars/makes/[make]/page.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/cars/makes/[make]/page.tsx
@@ -14,6 +14,10 @@ import {
 } from "@web/lib/metadata";
 import { getMakeDetails } from "@web/queries/cars";
 import { getMakeCoeComparison } from "@web/queries/cars/makes/coe-comparison";
+import {
+  getMakeFuelTypeBreakdown,
+  getMakeVehicleTypeBreakdown,
+} from "@web/queries/cars/makes/entity-breakdowns";
 import { getMakeFromSlug } from "@web/queries/cars/makes/get-make-from-slug";
 import type { Make } from "@web/types";
 import { fetchMonthsForCars, getMonthOrLatest } from "@web/utils/dates/months";
@@ -126,10 +130,13 @@ async function CarMakeContent({
 
   const { month } = await getMonthOrLatest(parsedMonth, "cars");
 
-  const [coeComparison, makeDetails] = await Promise.all([
-    getMakeCoeComparison(exactMake),
-    getMakeDetails(exactMake, month),
-  ]);
+  const [coeComparison, makeDetails, fuelTypeBreakdown, vehicleTypeBreakdown] =
+    await Promise.all([
+      getMakeCoeComparison(exactMake),
+      getMakeDetails(exactMake, month),
+      getMakeFuelTypeBreakdown(exactMake, month),
+      getMakeVehicleTypeBreakdown(exactMake, month),
+    ]);
 
   const cars = {
     make: exactMake,
@@ -149,7 +156,12 @@ async function CarMakeContent({
     <>
       <StructuredData data={structuredData} />
       <Suspense fallback={<SkeletonCard className="h-[560px] w-full" />}>
-        <MakeDetail cars={cars} coeComparison={coeComparison} />
+        <MakeDetail
+          cars={cars}
+          coeComparison={coeComparison}
+          fuelTypeBreakdown={fuelTypeBreakdown}
+          vehicleTypeBreakdown={vehicleTypeBreakdown}
+        />
       </Suspense>
     </>
   );

--- a/apps/web/src/queries/cars/makes/coe-comparison.test.ts
+++ b/apps/web/src/queries/cars/makes/coe-comparison.test.ts
@@ -1,0 +1,101 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { queueBatch, resetDbMocks } from "../../test-utils";
+import { getMakeCoeComparison } from "./coe-comparison";
+
+describe("getMakeCoeComparison", () => {
+  beforeEach(() => {
+    resetDbMocks();
+  });
+
+  it("should return empty array when no registrations exist", async () => {
+    queueBatch([[], []]);
+
+    const result = await getMakeCoeComparison("TOYOTA");
+
+    expect(result).toEqual([]);
+  });
+
+  it("should return data with COE premiums merged by month", async () => {
+    queueBatch([
+      [{ month: "2024-01", count: 50 }],
+      [
+        {
+          month: "2024-01",
+          categoryAPremium: 95000,
+          categoryBPremium: 110000,
+        },
+      ],
+    ]);
+
+    const result = await getMakeCoeComparison("TOYOTA");
+
+    expect(result).toEqual([
+      {
+        month: "2024-01",
+        registrations: 50,
+        categoryAPremium: 95000,
+        categoryBPremium: 110000,
+      },
+    ]);
+  });
+
+  it("should default to 0 when COE categoryAPremium is null", async () => {
+    queueBatch([
+      [{ month: "2024-01", count: 50 }],
+      [{ month: "2024-01", categoryAPremium: null, categoryBPremium: 110000 }],
+    ]);
+
+    const result = await getMakeCoeComparison("TOYOTA");
+
+    expect(result[0].categoryAPremium).toBe(0);
+    expect(result[0].categoryBPremium).toBe(110000);
+  });
+
+  it("should default to 0 when COE categoryBPremium is null", async () => {
+    queueBatch([
+      [{ month: "2024-01", count: 50 }],
+      [{ month: "2024-01", categoryAPremium: 95000, categoryBPremium: null }],
+    ]);
+
+    const result = await getMakeCoeComparison("TOYOTA");
+
+    expect(result[0].categoryAPremium).toBe(95000);
+    expect(result[0].categoryBPremium).toBe(0);
+  });
+
+  it("should return 0 premiums when month has no matching COE data", async () => {
+    queueBatch([
+      [{ month: "2024-01", count: 50 }],
+      [], // no COE data
+    ]);
+
+    const result = await getMakeCoeComparison("TOYOTA");
+
+    expect(result[0].categoryAPremium).toBe(0);
+    expect(result[0].categoryBPremium).toBe(0);
+  });
+
+  it("should handle multiple months with partial COE coverage", async () => {
+    queueBatch([
+      [
+        { month: "2024-01", count: 50 },
+        { month: "2024-02", count: 30 },
+      ],
+      [
+        {
+          month: "2024-01",
+          categoryAPremium: 95000,
+          categoryBPremium: 110000,
+        },
+        // no 2024-02 COE entry
+      ],
+    ]);
+
+    const result = await getMakeCoeComparison("TOYOTA");
+
+    expect(result).toHaveLength(2);
+    expect(result[0].categoryAPremium).toBe(95000);
+    expect(result[1].categoryAPremium).toBe(0); // no COE for 2024-02
+    expect(result[1].categoryBPremium).toBe(0);
+  });
+});

--- a/apps/web/src/queries/cars/makes/entity-breakdowns.test.ts
+++ b/apps/web/src/queries/cars/makes/entity-breakdowns.test.ts
@@ -1,0 +1,104 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { queueSelect, resetDbMocks } from "../../test-utils";
+import {
+  getMakeFuelTypeBreakdown,
+  getMakeVehicleTypeBreakdown,
+} from "./entity-breakdowns";
+
+describe("entity-breakdowns queries", () => {
+  beforeEach(() => {
+    resetDbMocks();
+  });
+
+  describe("getMakeFuelTypeBreakdown", () => {
+    it("should return fuel type breakdown without month filter", async () => {
+      queueSelect([
+        { name: "Petrol", value: 500 },
+        { name: "Electric", value: 300 },
+      ]);
+
+      const result = await getMakeFuelTypeBreakdown("TOYOTA");
+
+      expect(result).toEqual([
+        { name: "Petrol", value: 500 },
+        { name: "Electric", value: 300 },
+      ]);
+    });
+
+    it("should return fuel type breakdown with month filter", async () => {
+      queueSelect([{ name: "Hybrid", value: 200 }]);
+
+      const result = await getMakeFuelTypeBreakdown("TOYOTA", "2024-01");
+
+      expect(result).toEqual([{ name: "Hybrid", value: 200 }]);
+    });
+
+    it("should filter out rows with null fuel type name", async () => {
+      queueSelect([
+        { name: "Petrol", value: 500 },
+        { name: null, value: 100 },
+        { name: "Electric", value: 300 },
+      ]);
+
+      const result = await getMakeFuelTypeBreakdown("TOYOTA");
+
+      expect(result).toHaveLength(2);
+      expect(result).toEqual([
+        { name: "Petrol", value: 500 },
+        { name: "Electric", value: 300 },
+      ]);
+    });
+
+    it("should return empty array when no data exists", async () => {
+      queueSelect([]);
+
+      const result = await getMakeFuelTypeBreakdown("NONEXISTENT");
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe("getMakeVehicleTypeBreakdown", () => {
+    it("should return vehicle type breakdown without month filter", async () => {
+      queueSelect([
+        { name: "Saloon", value: 400 },
+        { name: "SUV", value: 200 },
+      ]);
+
+      const result = await getMakeVehicleTypeBreakdown("BMW");
+
+      expect(result).toEqual([
+        { name: "Saloon", value: 400 },
+        { name: "SUV", value: 200 },
+      ]);
+    });
+
+    it("should return vehicle type breakdown with month filter", async () => {
+      queueSelect([{ name: "Hatchback", value: 150 }]);
+
+      const result = await getMakeVehicleTypeBreakdown("BMW", "2024-01");
+
+      expect(result).toEqual([{ name: "Hatchback", value: 150 }]);
+    });
+
+    it("should filter out rows with null vehicle type name", async () => {
+      queueSelect([
+        { name: "Saloon", value: 400 },
+        { name: null, value: 50 },
+      ]);
+
+      const result = await getMakeVehicleTypeBreakdown("BMW");
+
+      expect(result).toHaveLength(1);
+      expect(result[0].name).toBe("Saloon");
+    });
+
+    it("should return empty array when no data exists", async () => {
+      queueSelect([]);
+
+      const result = await getMakeVehicleTypeBreakdown("NONEXISTENT");
+
+      expect(result).toEqual([]);
+    });
+  });
+});

--- a/apps/web/src/queries/cars/makes/entity-breakdowns.ts
+++ b/apps/web/src/queries/cars/makes/entity-breakdowns.ts
@@ -147,6 +147,68 @@ export async function getFuelTypeData(
   return result as FuelTypeData;
 }
 
+export async function getMakeFuelTypeBreakdown(
+  make: string,
+  month?: string | null,
+): Promise<{ name: string; value: number }[]> {
+  "use cache";
+  cacheLife("max");
+  cacheTag(`cars:make:${make}`);
+  if (month) {
+    cacheTag(`cars:month:${month}`);
+  }
+
+  const whereConditions = [ilike(cars.make, make)];
+  if (month) {
+    whereConditions.push(eq(cars.month, month));
+  }
+
+  const rows = await db
+    .select({
+      name: cars.fuelType,
+      value: sql<number>`cast(sum(${cars.number}) as int)`,
+    })
+    .from(cars)
+    .where(and(...whereConditions))
+    .groupBy(cars.fuelType)
+    .orderBy(desc(sql<number>`sum(${cars.number})`));
+
+  return rows
+    .filter((row) => row.name)
+    .map((row) => ({ name: row.name!, value: row.value }));
+}
+
+export async function getMakeVehicleTypeBreakdown(
+  make: string,
+  month?: string | null,
+): Promise<{ name: string; value: number }[]> {
+  "use cache";
+  cacheLife("max");
+  cacheTag(`cars:make:${make}`);
+  if (month) {
+    cacheTag(`cars:month:${month}`);
+  }
+
+  const whereConditions = [ilike(cars.make, make)];
+  if (month) {
+    whereConditions.push(eq(cars.month, month));
+  }
+
+  const rows = await db
+    .select({
+      name: cars.vehicleType,
+      value: sql<number>`cast(sum(${cars.number}) as int)`,
+    })
+    .from(cars)
+    .where(and(...whereConditions))
+    .groupBy(cars.vehicleType)
+    .orderBy(desc(sql<number>`sum(${cars.number})`));
+
+  return rows
+    .filter((row) => row.name)
+    .map((row) => ({ name: row.name!, value: row.value }));
+}
+
 export async function getVehicleTypeData(
   vehicleType: string,
   month?: string,

--- a/apps/web/src/queries/cars/makes/registration-stats.test.ts
+++ b/apps/web/src/queries/cars/makes/registration-stats.test.ts
@@ -1,0 +1,124 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { queueSelect, resetDbMocks } from "../../test-utils";
+import { getMakeRegistrationStats } from "./registration-stats";
+
+describe("getMakeRegistrationStats", () => {
+  beforeEach(() => {
+    resetDbMocks();
+  });
+
+  it("should return empty array when latest month query returns empty", async () => {
+    queueSelect([]);
+
+    const result = await getMakeRegistrationStats();
+
+    expect(result).toEqual([]);
+  });
+
+  it("should return empty array when latest month is null", async () => {
+    queueSelect([{ latestMonth: null }]);
+
+    const result = await getMakeRegistrationStats();
+
+    expect(result).toEqual([]);
+  });
+
+  it("should return registration stats with YoY change and trend data", async () => {
+    queueSelect([{ latestMonth: "2025-01" }]); // latest month
+    queueSelect([
+      // annual rows for 2025
+      { make: "TOYOTA", count: 1000 },
+      { make: "HONDA", count: 500 },
+    ]);
+    queueSelect([
+      // rolling 12-month trend rows
+      { make: "TOYOTA", month: "2024-02", count: 80 },
+      { make: "TOYOTA", month: "2024-03", count: 90 },
+      { make: "HONDA", month: "2024-02", count: 40 },
+    ]);
+    queueSelect([
+      // prev year rows
+      { make: "TOYOTA", count: 800 },
+      { make: "HONDA", count: 600 },
+    ]);
+
+    const result = await getMakeRegistrationStats();
+
+    expect(result).toHaveLength(2);
+
+    const toyota = result.find((r) => r.make === "TOYOTA");
+    expect(toyota?.count).toBe(1000);
+    expect(toyota?.share).toBeCloseTo((1000 / 1500) * 100, 1);
+    expect(toyota?.trend).toEqual([{ value: 80 }, { value: 90 }]);
+    expect(toyota?.yoyChange).toBeCloseTo(25, 1); // (1000-800)/800 * 100
+
+    const honda = result.find((r) => r.make === "HONDA");
+    expect(honda?.yoyChange).toBeCloseTo(-16.67, 1); // (500-600)/600 * 100
+  });
+
+  it("should return null yoyChange when make has no previous year data", async () => {
+    queueSelect([{ latestMonth: "2025-01" }]);
+    queueSelect([{ make: "NEWMAKE", count: 200 }]);
+    queueSelect([]);
+    queueSelect([]); // no prev year data
+
+    const result = await getMakeRegistrationStats();
+
+    expect(result[0].yoyChange).toBeNull();
+  });
+
+  it("should return null yoyChange when previous year count is zero", async () => {
+    queueSelect([{ latestMonth: "2025-01" }]);
+    queueSelect([{ make: "TOYOTA", count: 500 }]);
+    queueSelect([]);
+    queueSelect([{ make: "TOYOTA", count: 0 }]);
+
+    const result = await getMakeRegistrationStats();
+
+    expect(result[0].yoyChange).toBeNull();
+  });
+
+  it("should return zero share when grandTotal is zero", async () => {
+    queueSelect([{ latestMonth: "2025-01" }]);
+    queueSelect([{ make: "TOYOTA", count: 0 }]);
+    queueSelect([]);
+    queueSelect([]);
+
+    const result = await getMakeRegistrationStats();
+
+    expect(result[0].share).toBe(0);
+  });
+
+  it("should return empty trend array when make has no rolling monthly data", async () => {
+    queueSelect([{ latestMonth: "2025-01" }]);
+    queueSelect([{ make: "TOYOTA", count: 100 }]);
+    queueSelect([]); // no trend data
+    queueSelect([{ make: "TOYOTA", count: 80 }]);
+
+    const result = await getMakeRegistrationStats();
+
+    expect(result[0].trend).toEqual([]);
+  });
+
+  it("should accumulate multiple months per make in trend", async () => {
+    queueSelect([{ latestMonth: "2025-01" }]);
+    queueSelect([
+      { make: "TOYOTA", count: 100 },
+      { make: "HONDA", count: 50 },
+    ]);
+    queueSelect([
+      { make: "TOYOTA", month: "2024-11", count: 8 },
+      { make: "TOYOTA", month: "2024-12", count: 10 }, // same make, second entry
+      { make: "HONDA", month: "2024-12", count: 5 }, // new make entry
+    ]);
+    queueSelect([]);
+
+    const result = await getMakeRegistrationStats();
+
+    const toyota = result.find((r) => r.make === "TOYOTA");
+    expect(toyota?.trend).toHaveLength(2);
+
+    const honda = result.find((r) => r.make === "HONDA");
+    expect(honda?.trend).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
- Add `getMakeFuelTypeBreakdown` and `getMakeVehicleTypeBreakdown` queries to fetch aggregated breakdowns by fuel and vehicle type for a given make
- Add horizontal bar chart component (`TypeBreakdownChart`) and render both charts on the make detail page between the historical trend and COE comparison charts

Closes #257