### PR TITLE
Add month-to-month comparison feature

### DIFF
--- a/apps/web/src/app/(main)/(dashboard)/cars/components/comparison-bar-chart.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/cars/components/comparison-bar-chart.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import { Card, CardBody, CardHeader } from "@heroui/card";
+import {
+  ChartContainer,
+  ChartLegend,
+  ChartLegendContent,
+  ChartTooltip,
+  ChartTooltipContent,
+} from "@sgcarstrends/ui/components/chart";
+import { formatDateToMonthYear } from "@sgcarstrends/utils";
+import Typography from "@web/components/typography";
+import type { Registration } from "@web/types/cars";
+import { formatNumber } from "@web/utils/charts";
+import { Bar, BarChart, CartesianGrid, XAxis, YAxis } from "recharts";
+
+interface ComparisonBarChartProps {
+  monthA: Registration;
+  monthB: Registration;
+  type: "fuelType" | "vehicleType";
+  title: string;
+  description?: string;
+}
+
+export function ComparisonBarChart({
+  monthA,
+  monthB,
+  type,
+  title,
+  description,
+}: ComparisonBarChartProps) {
+  const allCategories = Array.from(
+    new Set([
+      ...monthA[type].map((item) => item.name),
+      ...monthB[type].map((item) => item.name),
+    ]),
+  );
+
+  const chartData = allCategories.map((name) => ({
+    name,
+    monthA: monthA[type].find((item) => item.name === name)?.count ?? 0,
+    monthB: monthB[type].find((item) => item.name === name)?.count ?? 0,
+  }));
+
+  const labelA = formatDateToMonthYear(monthA.month);
+  const labelB = formatDateToMonthYear(monthB.month);
+
+  const chartConfig = {
+    monthA: { label: labelA, color: "var(--chart-1)" },
+    monthB: { label: labelB, color: "var(--chart-3)" },
+  };
+
+  const height = Math.max(200, allCategories.length * 56);
+
+  return (
+    <Card className="rounded-2xl p-3">
+      <CardHeader className="flex flex-col items-start gap-2">
+        <Typography.H4>{title}</Typography.H4>
+        {description && <Typography.TextSm>{description}</Typography.TextSm>}
+      </CardHeader>
+      <CardBody>
+        <ChartContainer config={chartConfig} style={{ height }}>
+          <BarChart data={chartData} layout="vertical">
+            <CartesianGrid
+              horizontal={false}
+              strokeDasharray="3 3"
+              className="stroke-default-200"
+            />
+            <XAxis
+              type="number"
+              tickFormatter={formatNumber}
+              tickLine={false}
+              axisLine={false}
+            />
+            <YAxis
+              type="category"
+              dataKey="name"
+              tickLine={false}
+              axisLine={false}
+              width={110}
+            />
+            <ChartTooltip
+              cursor={{ fill: "hsl(var(--muted))", opacity: 0.2 }}
+              content={<ChartTooltipContent />}
+            />
+            <ChartLegend content={<ChartLegendContent />} />
+            <Bar dataKey="monthA" fill="var(--chart-1)" radius={[0, 4, 4, 0]} />
+            <Bar dataKey="monthB" fill="var(--chart-3)" radius={[0, 4, 4, 0]} />
+          </BarChart>
+        </ChartContainer>
+      </CardBody>
+    </Card>
+  );
+}

--- a/apps/web/src/app/(main)/(dashboard)/cars/components/comparison-summary.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/cars/components/comparison-summary.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import { Card, CardBody, CardHeader } from "@heroui/card";
+import { Chip } from "@heroui/chip";
+import { formatDateToMonthYear } from "@sgcarstrends/utils";
+import { AnimatedNumber } from "@web/components/animated-number";
+import Typography from "@web/components/typography";
+import type { Registration } from "@web/types/cars";
+import { formatNumber, formatPercent } from "@web/utils/charts";
+import { ArrowDownRight, ArrowUpRight } from "lucide-react";
+
+interface ComparisonSummaryProps {
+  monthA: Registration;
+  monthB: Registration;
+}
+
+export function ComparisonSummary({ monthA, monthB }: ComparisonSummaryProps) {
+  const change =
+    monthB.total > 0 ? (monthA.total - monthB.total) / monthB.total : 0;
+  const diff = monthA.total - monthB.total;
+  const isNeutral = monthB.total === 0 || change === 0;
+  const isPositive = change > 0;
+
+  return (
+    <Card className="rounded-2xl p-3">
+      <CardHeader className="flex flex-col items-start gap-2">
+        <Typography.H4>Total Registrations</Typography.H4>
+      </CardHeader>
+      <CardBody className="flex flex-col gap-4">
+        <div className="grid grid-cols-2 gap-4">
+          <div className="flex flex-col gap-1">
+            <Typography.TextSm>
+              {formatDateToMonthYear(monthA.month)}
+            </Typography.TextSm>
+            <div className="font-semibold text-4xl text-primary tabular-nums">
+              <AnimatedNumber value={monthA.total} />
+            </div>
+          </div>
+          <div className="flex flex-col gap-1">
+            <Typography.TextSm>
+              {formatDateToMonthYear(monthB.month)}
+            </Typography.TextSm>
+            <div className="font-semibold text-4xl text-default-500 tabular-nums">
+              <AnimatedNumber value={monthB.total} />
+            </div>
+          </div>
+        </div>
+        <div className="flex items-center gap-2">
+          <Chip
+            variant="flat"
+            color={isNeutral ? "default" : isPositive ? "success" : "danger"}
+            startContent={
+              isNeutral ? null : isPositive ? (
+                <ArrowUpRight className="size-4" />
+              ) : (
+                <ArrowDownRight className="size-4" />
+              )
+            }
+          >
+            {formatPercent(Math.abs(change), { maximumFractionDigits: 1 })}
+          </Chip>
+          <span className="text-default-500 text-sm">
+            {diff >= 0 ? "+" : ""}
+            {formatNumber(diff)} registrations
+          </span>
+        </div>
+      </CardBody>
+    </Card>
+  );
+}

--- a/apps/web/src/app/(main)/(dashboard)/cars/search-params.ts
+++ b/apps/web/src/app/(main)/(dashboard)/cars/search-params.ts
@@ -2,6 +2,8 @@ import { createLoader, parseAsString } from "nuqs/server";
 
 export const carsSearchParams = {
   month: parseAsString,
+  compareA: parseAsString,
+  compareB: parseAsString,
 };
 
 export const loadSearchParams = createLoader(carsSearchParams);

--- a/apps/web/src/app/(main)/(dashboard)/cars/trends-compare-button.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/cars/trends-compare-button.tsx
@@ -1,11 +1,22 @@
 "use client";
 
 import { Button, useDisclosure } from "@heroui/react";
-import { BetaChip } from "@web/components/shared/chips";
 import { TrendsComparison } from "@web/components/trends-comparison";
+import type { ComparisonData } from "@web/queries/cars/compare";
+import type { Month } from "@web/types";
 import { TrendingUp } from "lucide-react";
 
-export function TrendsCompareButton() {
+interface TrendsCompareButtonProps {
+  currentMonth: string;
+  months: Month[];
+  comparisonData: ComparisonData | false;
+}
+
+export function TrendsCompareButton({
+  currentMonth,
+  months,
+  comparisonData,
+}: TrendsCompareButtonProps) {
   const { isOpen, onOpen, onOpenChange } = useDisclosure();
 
   return (
@@ -15,14 +26,19 @@ export function TrendsCompareButton() {
           color="primary"
           variant="shadow"
           startContent={<TrendingUp className="size-4" />}
-          endContent={<BetaChip />}
           onPress={onOpen}
         >
           Compare Trends
         </Button>
       </div>
 
-      <TrendsComparison isOpen={isOpen} onOpenChange={onOpenChange} />
+      <TrendsComparison
+        isOpen={isOpen}
+        onOpenChange={onOpenChange}
+        currentMonth={currentMonth}
+        months={months}
+        comparisonData={comparisonData}
+      />
     </>
   );
 }

--- a/apps/web/src/components/shared/chips.test.tsx
+++ b/apps/web/src/components/shared/chips.test.tsx
@@ -1,12 +1,5 @@
 import { render } from "@testing-library/react";
-import { BetaChip, NewChip } from "./chips";
-
-describe("BetaChip", () => {
-  it("should render with default props", () => {
-    const { getByText } = render(<BetaChip />);
-    expect(getByText("Beta")).toBeInTheDocument();
-  });
-});
+import { NewChip } from "./chips";
 
 describe("NewChip", () => {
   it("should render with default props", () => {

--- a/apps/web/src/components/shared/chips.tsx
+++ b/apps/web/src/components/shared/chips.tsx
@@ -1,13 +1,5 @@
 import { Chip } from "@heroui/chip";
 
-export function BetaChip() {
-  return (
-    <Chip color="warning" size="sm" variant="bordered">
-      Beta
-    </Chip>
-  );
-}
-
 export function NewChip() {
   return (
     <Chip color="primary" size="sm">

--- a/apps/web/src/components/shared/index.ts
+++ b/apps/web/src/components/shared/index.ts
@@ -1,4 +1,4 @@
-export { BetaChip, NewChip } from "./chips";
+export { NewChip } from "./chips";
 export { Currency } from "./currency";
 export { EmptyState } from "./empty-state";
 export { LastUpdated } from "./last-updated";

--- a/apps/web/src/components/trends-comparison.test.tsx
+++ b/apps/web/src/components/trends-comparison.test.tsx
@@ -1,11 +1,39 @@
 import { render, screen } from "@testing-library/react";
 import { TrendsComparison } from "@web/components/trends-comparison";
+import { NuqsTestingAdapter } from "nuqs/adapters/testing";
 import { vi } from "vitest";
+
+const mockMonths = ["2024-01", "2023-12", "2023-11"];
+
+const mockComparisonData = {
+  monthA: {
+    month: "2024-01",
+    total: 100,
+    fuelType: [{ name: "Petrol", count: 60 }],
+    vehicleType: [{ name: "Saloon", count: 80 }],
+  },
+  monthB: {
+    month: "2023-12",
+    total: 90,
+    fuelType: [{ name: "Petrol", count: 50 }],
+    vehicleType: [{ name: "Saloon", count: 70 }],
+  },
+};
 
 describe("TrendsComparison", () => {
   it("should render TrendsComparison content when open", () => {
     const handleChange = vi.fn();
-    render(<TrendsComparison isOpen onOpenChange={handleChange} />);
+    render(
+      <NuqsTestingAdapter>
+        <TrendsComparison
+          isOpen
+          onOpenChange={handleChange}
+          currentMonth="2024-01"
+          months={mockMonths}
+          comparisonData={mockComparisonData}
+        />
+      </NuqsTestingAdapter>,
+    );
 
     expect(screen.getByText("Trends Comparison")).toBeInTheDocument();
   });

--- a/apps/web/src/components/trends-comparison.tsx
+++ b/apps/web/src/components/trends-comparison.tsx
@@ -1,16 +1,122 @@
 "use client";
 
-import { Drawer, DrawerBody, DrawerContent, DrawerHeader } from "@heroui/react";
+import {
+  Autocomplete,
+  AutocompleteItem,
+  AutocompleteSection,
+  Drawer,
+  DrawerBody,
+  DrawerContent,
+  DrawerHeader,
+} from "@heroui/react";
+import { formatDateToMonthYear } from "@sgcarstrends/utils";
+import { ComparisonBarChart } from "@web/app/(main)/(dashboard)/cars/components/comparison-bar-chart";
+import { ComparisonSummary } from "@web/app/(main)/(dashboard)/cars/components/comparison-summary";
+import type { ComparisonData } from "@web/queries/cars/compare";
+import type { Month } from "@web/types";
+import { groupByYear } from "@web/utils/group-by-year";
+import { format, subMonths } from "date-fns";
+import { Calendar } from "lucide-react";
+import { parseAsString, useQueryState } from "nuqs";
+import { useEffect, useMemo } from "react";
 
 interface TrendsComparisonProps {
   isOpen: boolean;
   onOpenChange: (isOpen: boolean) => void;
+  currentMonth: string;
+  months: Month[];
+  comparisonData: ComparisonData | false;
+}
+
+function getDefaultMonthB(currentMonth: string, months: Month[]): string {
+  const previousMonthStr = format(
+    subMonths(new Date(`${currentMonth}-01`), 1),
+    "yyyy-MM",
+  );
+  if (months.includes(previousMonthStr)) {
+    return previousMonthStr;
+  }
+  return months[1] ?? months[0] ?? currentMonth;
 }
 
 export function TrendsComparison({
   isOpen,
   onOpenChange,
+  currentMonth,
+  months,
+  comparisonData,
 }: TrendsComparisonProps) {
+  const [compareA, setCompareA] = useQueryState(
+    "compareA",
+    parseAsString.withOptions({ shallow: false }),
+  );
+  const [compareB, setCompareB] = useQueryState(
+    "compareB",
+    parseAsString.withOptions({ shallow: false }),
+  );
+
+  const monthA = compareA ?? currentMonth;
+  const monthB = compareB ?? getDefaultMonthB(currentMonth, months);
+
+  // Set default params when drawer opens for the first time
+  useEffect(() => {
+    if (isOpen && !compareA && !compareB) {
+      setCompareA(currentMonth);
+      setCompareB(getDefaultMonthB(currentMonth, months));
+    }
+  }, [
+    isOpen,
+    compareA,
+    compareB,
+    currentMonth,
+    months,
+    setCompareA,
+    setCompareB,
+  ]);
+
+  // Clean up params when drawer closes
+  useEffect(() => {
+    if (!isOpen && (compareA || compareB)) {
+      setCompareA(null);
+      setCompareB(null);
+    }
+  }, [isOpen, compareA, compareB, setCompareA, setCompareB]);
+
+  const sortedMonths = useMemo(
+    () => Object.entries(groupByYear(months)).slice().reverse(),
+    [months],
+  );
+
+  const renderMonthPicker = (
+    label: string,
+    value: string,
+    onChange: (val: string) => void,
+  ) => (
+    <Autocomplete
+      label={label}
+      selectedKey={value}
+      onSelectionChange={(key) => key && onChange(key as string)}
+      startContent={<Calendar className="size-4" />}
+      variant="bordered"
+    >
+      {sortedMonths.map(([year, yearMonths]) => (
+        <AutocompleteSection key={year} title={year}>
+          {yearMonths.map((m) => {
+            const date = `${year}-${m}`;
+            return (
+              <AutocompleteItem
+                key={date}
+                textValue={formatDateToMonthYear(date)}
+              >
+                {formatDateToMonthYear(date)}
+              </AutocompleteItem>
+            );
+          })}
+        </AutocompleteSection>
+      ))}
+    </Autocomplete>
+  );
+
   return (
     <Drawer
       isOpen={isOpen}
@@ -30,8 +136,36 @@ export function TrendsComparison({
             </p>
           </div>
         </DrawerHeader>
-        <DrawerBody>
-          <div className="p-16 text-center text-7xl">Coming Soon!</div>
+        <DrawerBody className="flex flex-col gap-6">
+          <div className="grid grid-cols-2 gap-4">
+            {renderMonthPicker("Month A", monthA, setCompareA)}
+            {renderMonthPicker("Month B", monthB, setCompareB)}
+          </div>
+          {!comparisonData && (
+            <div className="flex justify-center py-8">
+              <span className="text-default-500">Loading comparison data…</span>
+            </div>
+          )}
+          {comparisonData && (
+            <div className="flex flex-col gap-4">
+              <ComparisonSummary
+                monthA={comparisonData.monthA}
+                monthB={comparisonData.monthB}
+              />
+              <ComparisonBarChart
+                monthA={comparisonData.monthA}
+                monthB={comparisonData.monthB}
+                type="fuelType"
+                title="Fuel Type Breakdown"
+              />
+              <ComparisonBarChart
+                monthA={comparisonData.monthA}
+                monthB={comparisonData.monthB}
+                type="vehicleType"
+                title="Vehicle Type Breakdown"
+              />
+            </div>
+          )}
         </DrawerBody>
       </DrawerContent>
     </Drawer>

--- a/apps/web/src/queries/cars/compare.ts
+++ b/apps/web/src/queries/cars/compare.ts
@@ -1,0 +1,24 @@
+import type { Registration } from "@web/types/cars";
+import { cacheLife, cacheTag } from "next/cache";
+import { getCarsData } from "./monthly-registrations";
+
+export interface ComparisonData {
+  monthA: Registration;
+  monthB: Registration;
+}
+
+export async function getComparisonData(
+  monthA: string,
+  monthB: string,
+): Promise<ComparisonData> {
+  "use cache";
+  cacheLife("max");
+  cacheTag(`cars:month:${monthA}`, `cars:month:${monthB}`);
+
+  const [dataA, dataB] = await Promise.all([
+    getCarsData(monthA),
+    getCarsData(monthB),
+  ]);
+
+  return { monthA: dataA, monthB: dataB };
+}

--- a/apps/web/src/queries/cars/index.ts
+++ b/apps/web/src/queries/cars/index.ts
@@ -1,5 +1,6 @@
 export * from "./categories";
 export * from "./category-summary";
+export * from "./compare";
 export * from "./filter-options";
 export * from "./latest-month";
 export * from "./makes";


### PR DESCRIPTION
## Summary
- Replace "Coming Soon" stub with a working comparison drawer on `/cars`
- Two month pickers let users compare registration data across any two months
- Shows side-by-side total registrations with percentage change, plus grouped bar charts for fuel type and vehicle type breakdowns
- Uses cached queries (`"use cache"`) and nuqs URL params (`compareA`/`compareB`) for server-driven data fetching

## Changes
- **New**: `comparison-summary.tsx` — animated totals with change chip
- **New**: `comparison-bar-chart.tsx` — horizontal grouped bar chart (Month A vs Month B)
- **New**: `queries/cars/compare.ts` — cached query fetching two months in parallel
- **Updated**: `trends-comparison.tsx` — rewritten drawer with month pickers and comparison UI
- **Updated**: `trends-compare-button.tsx` — accepts comparison data from server component
- **Updated**: `cars/page.tsx` — removed `UnreleasedFeature` wrapper, added `CarsCompareSection`
- **Removed**: `BetaChip` component (no longer used)

Closes #261