### PR TITLE
Add blog search with hybrid keyword and vector matching

### DIFF
--- a/apps/web/src/app/(main)/blog/components/blog-list-section.tsx
+++ b/apps/web/src/app/(main)/blog/components/blog-list-section.tsx
@@ -1,22 +1,34 @@
 import { BlogList } from "@web/app/(main)/blog/components/blog-list";
 import { ListSkeleton } from "@web/components/shared/skeleton";
-import { getAllPosts } from "@web/queries/posts";
+import { getAllPosts, searchPosts } from "@web/queries/posts";
 import { Suspense } from "react";
 
-async function BlogListContent() {
-  const posts = await getAllPosts();
+interface BlogListSectionProps {
+  query: string;
+}
 
-  return <BlogList posts={posts} />;
+function fetchPosts(query: string) {
+  if (query) {
+    return searchPosts(query);
+  }
+
+  return getAllPosts();
+}
+
+async function BlogListContent({ query }: BlogListSectionProps) {
+  const posts = await fetchPosts(query);
+
+  return <BlogList posts={posts} query={query} />;
 }
 
 function BlogListSkeleton() {
   return <ListSkeleton count={3} />;
 }
 
-export function BlogListSection() {
+export function BlogListSection({ query }: BlogListSectionProps) {
   return (
-    <Suspense fallback={<BlogListSkeleton />}>
-      <BlogListContent />
+    <Suspense key={query} fallback={<BlogListSkeleton />}>
+      <BlogListContent query={query} />
     </Suspense>
   );
 }

--- a/apps/web/src/app/(main)/blog/components/blog-list/client.tsx
+++ b/apps/web/src/app/(main)/blog/components/blog-list/client.tsx
@@ -18,6 +18,7 @@ interface PostCounts {
 interface BlogListClientProps {
   posts: SelectPost[];
   counts: PostCounts;
+  query: string;
 }
 
 interface PostsGridProps {
@@ -47,7 +48,7 @@ const PostsGrid = ({ posts }: PostsGridProps) => {
   );
 };
 
-export function BlogListClient({ posts, counts }: BlogListClientProps) {
+export function BlogListClient({ posts, counts, query }: BlogListClientProps) {
   const [selectedTab, setSelectedTab] = useState("all");
 
   const filteredPosts = useMemo(() => {
@@ -63,7 +64,23 @@ export function BlogListClient({ posts, counts }: BlogListClientProps) {
   if (posts.length === 0) {
     return (
       <div className="py-12 text-center">
-        <p className="text-muted-foreground">No blog posts available.</p>
+        <p className="text-muted-foreground">
+          {query
+            ? `No results found for "${query}".`
+            : "No blog posts available."}
+        </p>
+      </div>
+    );
+  }
+
+  if (query) {
+    return (
+      <div className="flex flex-col gap-8">
+        <p className="text-default-600">
+          {filteredPosts.length} result{filteredPosts.length !== 1 && "s"} for "
+          {query}"
+        </p>
+        <PostsGrid posts={filteredPosts} />
       </div>
     );
   }

--- a/apps/web/src/app/(main)/blog/components/blog-list/server.tsx
+++ b/apps/web/src/app/(main)/blog/components/blog-list/server.tsx
@@ -4,9 +4,10 @@ import { BlogListClient } from "./client";
 
 interface BlogListProps {
   posts: SelectPost[];
+  query: string;
 }
 
-export async function BlogList({ posts }: BlogListProps) {
+export async function BlogList({ posts, query }: BlogListProps) {
   const postCounts = await getPostCountsByCategory();
 
   const counts = {
@@ -18,5 +19,5 @@ export async function BlogList({ posts }: BlogListProps) {
     ),
   };
 
-  return <BlogListClient posts={posts} counts={counts} />;
+  return <BlogListClient posts={posts} counts={counts} query={query} />;
 }

--- a/apps/web/src/app/(main)/blog/components/blog-search-input.tsx
+++ b/apps/web/src/app/(main)/blog/components/blog-search-input.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { Input } from "@heroui/input";
+import { Search, X } from "lucide-react";
+import { parseAsString, useQueryState } from "nuqs";
+
+export function BlogSearchInput() {
+  const [query, setQuery] = useQueryState(
+    "q",
+    parseAsString
+      .withDefault("")
+      .withOptions({ shallow: false, throttleMs: 300 }),
+  );
+
+  return (
+    <Input
+      type="search"
+      placeholder="Search blog posts..."
+      value={query}
+      onValueChange={setQuery}
+      startContent={<Search className="size-4 text-default-400" />}
+      endContent={
+        query ? (
+          <button
+            type="button"
+            onClick={() => setQuery("")}
+            aria-label="Clear search"
+          >
+            <X className="size-4 text-default-400" />
+          </button>
+        ) : null
+      }
+      classNames={{ inputWrapper: "rounded-full" }}
+      isClearable={false}
+      aria-label="Search blog posts"
+    />
+  );
+}

--- a/apps/web/src/app/(main)/blog/page.tsx
+++ b/apps/web/src/app/(main)/blog/page.tsx
@@ -1,8 +1,12 @@
 import { BlogListSection } from "@web/app/(main)/blog/components/blog-list-section";
 import { BlogPageHeader } from "@web/app/(main)/blog/components/blog-page-header";
+import { BlogSearchInput } from "@web/app/(main)/blog/components/blog-search-input";
 import { PopularPostsSection } from "@web/app/(main)/blog/components/popular-posts-section";
+import { loadSearchParams } from "@web/app/(main)/blog/search-params";
 import { StructuredData } from "@web/components/structured-data";
 import type { Metadata } from "next";
+import type { SearchParams } from "nuqs/server";
+import { Suspense } from "react";
 import type { Blog, WithContext } from "schema-dts";
 
 const title = "Blog";
@@ -35,14 +39,33 @@ export const metadata: Metadata = {
   },
 };
 
-export default function BlogPage() {
+interface BlogPageProps {
+  searchParams: Promise<SearchParams>;
+}
+
+async function BlogListWithSearch({
+  searchParams,
+}: {
+  searchParams: Promise<SearchParams>;
+}) {
+  const { q: query } = await loadSearchParams(searchParams);
+
+  return <BlogListSection query={query} />;
+}
+
+export default function BlogPage({ searchParams }: BlogPageProps) {
   return (
     <>
       <StructuredData data={structuredData} />
       <section className="flex flex-col gap-8">
         <BlogPageHeader title={title} description={description} />
+        <Suspense>
+          <BlogSearchInput />
+        </Suspense>
         <PopularPostsSection />
-        <BlogListSection />
+        <Suspense>
+          <BlogListWithSearch searchParams={searchParams} />
+        </Suspense>
       </section>
     </>
   );

--- a/apps/web/src/app/(main)/blog/search-params.ts
+++ b/apps/web/src/app/(main)/blog/search-params.ts
@@ -1,0 +1,7 @@
+import { createLoader, parseAsString } from "nuqs/server";
+
+export const blogSearchParams = {
+  q: parseAsString.withDefault(""),
+};
+
+export const loadSearchParams = createLoader(blogSearchParams);


### PR DESCRIPTION
- Add URL-driven search input (`?q=`) to `/blog` with ILIKE keyword matching on title/excerpt, falling back to pgvector semantic search via cosine similarity
- Wire search through Suspense boundaries for PPR compatibility with throttled input (300ms)

Closes #436