### PR TITLE
refactor(web): add configurable partition field to updater

### DIFF
--- a/apps/web/src/lib/updater/index.ts
+++ b/apps/web/src/lib/updater/index.ts
@@ -4,4 +4,4 @@ export type {
   UpdaterOptions,
   UpdaterResult,
 } from "./updater";
-export { Updater } from "./updater";
+export { update } from "./updater";

--- a/apps/web/src/lib/updater/updater.ts
+++ b/apps/web/src/lib/updater/updater.ts
@@ -14,6 +14,7 @@ export interface UpdaterConfig<T> {
   table: Table;
   url: string;
   csvFile?: string;
+  partitionField?: string;
   keyFields: string[];
   csvTransformOptions?: CSVTransformOptions<T>;
 }
@@ -33,206 +34,178 @@ export interface UpdaterOptions {
 
 const DEFAULT_BATCH_SIZE = 5000;
 
-export class Updater<T> {
-  private readonly config: UpdaterConfig<T>;
-  private readonly checksum: Checksum;
-  private readonly batchSize: number;
-  private readonly tableName: string;
+export async function update<T>(
+  config: UpdaterConfig<T>,
+  options: UpdaterOptions = {},
+): Promise<UpdaterResult> {
+  const checksumService = options.checksum || new Checksum();
+  const batchSize = options.batchSize || DEFAULT_BATCH_SIZE;
+  const tableName = getTableName(config.table);
+  const partitionField = config.partitionField ?? "month";
 
-  constructor(config: UpdaterConfig<T>, options: UpdaterOptions = {}) {
-    this.config = config;
-    this.checksum = options.checksum || new Checksum();
-    this.batchSize = options.batchSize || DEFAULT_BATCH_SIZE;
-    this.tableName = getTableName(config.table);
-  }
+  const { url, csvFile, csvTransformOptions = {} } = config;
 
-  async update(): Promise<UpdaterResult> {
-    const { filePath, checksum } = await this.downloadAndVerify();
+  // === Download and verify ===
+  const extractedFileName = await downloadFile(url, csvFile);
+  const destinationPath = path.join(AWS_LAMBDA_TEMP_DIR, extractedFileName);
+  console.log("Destination path:", destinationPath);
 
-    if (!checksum) {
-      return {
-        table: this.tableName,
-        recordsProcessed: 0,
-        message: `File has not changed since last update`,
-        timestamp: new Date().toISOString(),
-      };
-    }
+  const checksum = await calculateChecksum(destinationPath);
+  console.log("Checksum:", checksum);
 
-    const processedData = await this.processData(filePath);
-    const totalInserted = await this.insertNewRecords(processedData);
+  const cachedChecksum =
+    await checksumService.getCachedChecksum(extractedFileName);
+  console.log("Cached checksum:", cachedChecksum);
 
+  if (!cachedChecksum) {
+    console.log("No cached checksum found. This might be the first run.");
+    await checksumService.cacheChecksum(extractedFileName, checksum);
+  } else if (cachedChecksum === checksum) {
+    console.log(
+      `File has not changed since last update (Checksum: ${checksum})`,
+    );
     return {
-      table: this.tableName,
-      recordsProcessed: totalInserted,
-      message:
-        totalInserted > 0
-          ? `${totalInserted} record(s) inserted`
-          : "No new data to insert. The provided data matches the existing records.",
+      table: tableName,
+      recordsProcessed: 0,
+      message: "File has not changed since last update",
       timestamp: new Date().toISOString(),
     };
   }
 
-  private async downloadAndVerify(): Promise<{
-    filePath: string;
-    checksum: string | null;
-  }> {
-    const { url, csvFile } = this.config;
+  await checksumService.cacheChecksum(extractedFileName, checksum);
+  console.log("Checksum has been changed.");
 
-    // Download and extract file
-    const extractedFileName = await downloadFile(url, csvFile);
-    const destinationPath = path.join(AWS_LAMBDA_TEMP_DIR, extractedFileName);
-    console.log("Destination path:", destinationPath);
+  // === Process CSV ===
+  const processedData = await processCsv<T>(
+    destinationPath,
+    csvTransformOptions,
+  );
 
-    // Calculate checksum of the downloaded file
-    const checksum = await calculateChecksum(destinationPath);
-    console.log("Checksum:", checksum);
+  // === Insert new records ===
+  const { table, keyFields } = config;
 
-    // Get previously stored checksum
-    const cachedChecksum =
-      await this.checksum.getCachedChecksum(extractedFileName);
-    console.log("Cached checksum:", cachedChecksum);
+  // biome-ignore lint/suspicious/noExplicitAny: Dynamic field access requires any type
+  const tableColumns = table as any;
 
-    if (!cachedChecksum) {
-      console.log("No cached checksum found. This might be the first run.");
-      await this.checksum.cacheChecksum(extractedFileName, checksum);
-    } else if (cachedChecksum === checksum) {
-      const message = `File has not changed since last update (Checksum: ${checksum})`;
-      console.log(message);
-      return { filePath: destinationPath, checksum: null };
+  // === Phase 1: Partition-Level Deduplication ===
+  const incomingPartitions = new Set(
+    processedData.map(
+      (record) => (record as Record<string, unknown>)[partitionField] as string,
+    ),
+  );
+
+  const existingPartitionsQuery = await db
+    .selectDistinct({ [partitionField]: tableColumns[partitionField] })
+    .from(table);
+  const existingPartitions = new Set(
+    existingPartitionsQuery.map(
+      (record) => (record as Record<string, unknown>)[partitionField] as string,
+    ),
+  );
+
+  const newPartitions = incomingPartitions.difference(existingPartitions);
+
+  console.log(
+    `Partition analysis (${partitionField}): ${incomingPartitions.size} incoming, ${existingPartitions.size} existing, ${newPartitions.size} new`,
+  );
+
+  const recordsFromNewPartitions: T[] = [];
+  const recordsFromOverlappingPartitions: T[] = [];
+
+  for (const record of processedData) {
+    const partition = (record as Record<string, unknown>)[
+      partitionField
+    ] as string;
+    if (newPartitions.has(partition)) {
+      recordsFromNewPartitions.push(record);
+    } else {
+      recordsFromOverlappingPartitions.push(record);
     }
-
-    await this.checksum.cacheChecksum(extractedFileName, checksum);
-    console.log("Checksum has been changed.");
-
-    return { filePath: destinationPath, checksum };
   }
 
-  private async processData(filePath: string): Promise<T[]> {
-    const { csvTransformOptions = {} } = this.config;
+  console.log(
+    `Records: ${recordsFromNewPartitions.length} from new ${partitionField}s, ${recordsFromOverlappingPartitions.length} from overlapping ${partitionField}s`,
+  );
 
-    // Process CSV with custom transformations
-    return await processCsv(filePath, csvTransformOptions);
-  }
+  // === Phase 2: Key-Level Comparison (overlapping partitions only) ===
+  let newRecordsFromOverlapping: T[] = [];
 
-  private async insertNewRecords(processedData: T[]): Promise<number> {
-    const { table, keyFields } = this.config;
+  if (recordsFromOverlappingPartitions.length > 0) {
+    const overlappingPartitions =
+      incomingPartitions.intersection(existingPartitions);
 
-    // biome-ignore lint/suspicious/noExplicitAny: Dynamic field access requires any type
-    const tableColumns = table as any;
+    const existingKeysQuery = await db
+      .select(
+        Object.fromEntries(
+          keyFields.map((field) => [field, tableColumns[field]]),
+        ),
+      )
+      .from(table)
+      .where(inArray(tableColumns[partitionField], [...overlappingPartitions]));
 
-    // === Phase 1: Month-Level Partitioning ===
-    // Extract distinct months from incoming data
-    const incomingMonths = new Set(
-      processedData.map(
-        (record) => (record as Record<string, unknown>).month as string,
+    const existingKeys = new Set(
+      existingKeysQuery.map((record) => createUniqueKey(record, keyFields)),
+    );
+
+    const incomingKeys = new Set(
+      recordsFromOverlappingPartitions.map((record) =>
+        createUniqueKey(record as Record<string, unknown>, keyFields),
       ),
     );
 
-    // Query distinct months from DB
-    const existingMonthsQuery = await db
-      .selectDistinct({ month: tableColumns.month })
-      .from(table);
-    const existingMonths = new Set(
-      existingMonthsQuery.map((record) => record.month as string),
-    );
-
-    // Use Set.difference() to find brand new months (ES2025)
-    const newMonths = incomingMonths.difference(existingMonths);
-
-    console.log(
-      `Month analysis: ${incomingMonths.size} incoming, ${existingMonths.size} existing, ${newMonths.size} new`,
-    );
-
-    // Separate records: new months skip key comparison entirely
-    const recordsFromNewMonths: T[] = [];
-    const recordsFromOverlappingMonths: T[] = [];
-
-    for (const record of processedData) {
-      const month = (record as Record<string, unknown>).month as string;
-      if (newMonths.has(month)) {
-        recordsFromNewMonths.push(record);
-      } else {
-        recordsFromOverlappingMonths.push(record);
-      }
-    }
-
-    console.log(
-      `Records: ${recordsFromNewMonths.length} from new months, ${recordsFromOverlappingMonths.length} from overlapping months`,
-    );
-
-    // === Phase 2: Key-Level Comparison (overlapping months only) ===
-    let newRecordsFromOverlapping: T[] = [];
-
-    if (recordsFromOverlappingMonths.length > 0) {
-      // Use Set.intersection() to find overlapping months (ES2025)
-      const overlappingMonths = incomingMonths.intersection(existingMonths);
-
-      // Scoped database query: only fetch keys for overlapping months
-      const existingKeysQuery = await db
-        .select(
-          Object.fromEntries(
-            keyFields.map((field) => [field, tableColumns[field]]),
-          ),
-        )
-        .from(table)
-        .where(inArray(tableColumns.month, [...overlappingMonths]));
-
-      const existingKeys = new Set(
-        existingKeysQuery.map((record) => createUniqueKey(record, keyFields)),
-      );
-
-      // Create Set of incoming keys for overlapping months
-      const incomingKeys = new Set(
-        recordsFromOverlappingMonths.map((record) =>
-          createUniqueKey(record as Record<string, unknown>, keyFields),
-        ),
-      );
-
-      // Use Set.isSubsetOf() for early exit when all incoming keys already exist (ES2025)
-      if (incomingKeys.isSubsetOf(existingKeys)) {
-        console.log(
-          "Early exit: all records from overlapping months already exist",
-        );
-      } else {
-        // Filter remaining records with has()
-        newRecordsFromOverlapping = recordsFromOverlappingMonths.filter(
-          (record) => {
-            const identifier = createUniqueKey(
-              record as Record<string, unknown>,
-              keyFields,
-            );
-            return !existingKeys.has(identifier);
-          },
-        );
-      }
-    }
-
-    // Combine all new records
-    const newRecords = [...recordsFromNewMonths, ...newRecordsFromOverlapping];
-
-    // Return early when there are no new records to be added to the database
-    if (newRecords.length === 0) {
-      return 0;
-    }
-
-    // Process in batches
-    let totalInserted = 0;
-    const start = performance.now();
-
-    for (let i = 0; i < newRecords.length; i += this.batchSize) {
-      const batch = newRecords.slice(i, i + this.batchSize);
-      const inserted = await db.insert(table).values(batch).returning();
-      totalInserted += inserted.length;
+    if (incomingKeys.isSubsetOf(existingKeys)) {
       console.log(
-        `Inserted batch of ${inserted.length} records. Total: ${totalInserted}`,
+        `Early exit: all records from overlapping ${partitionField}s already exist`,
+      );
+    } else {
+      newRecordsFromOverlapping = recordsFromOverlappingPartitions.filter(
+        (record) => {
+          const identifier = createUniqueKey(
+            record as Record<string, unknown>,
+            keyFields,
+          );
+          return !existingKeys.has(identifier);
+        },
       );
     }
-
-    const end = performance.now();
-    console.log(
-      `Inserted ${totalInserted} record(s) in ${Math.round(end - start)}ms`,
-    );
-
-    return totalInserted;
   }
+
+  const newRecords = [
+    ...recordsFromNewPartitions,
+    ...newRecordsFromOverlapping,
+  ];
+
+  if (newRecords.length === 0) {
+    return {
+      table: tableName,
+      recordsProcessed: 0,
+      message:
+        "No new data to insert. The provided data matches the existing records.",
+      timestamp: new Date().toISOString(),
+    };
+  }
+
+  let totalInserted = 0;
+  const start = performance.now();
+
+  for (let i = 0; i < newRecords.length; i += batchSize) {
+    const batch = newRecords.slice(i, i + batchSize);
+    const inserted = await db.insert(table).values(batch).returning();
+    totalInserted += inserted.length;
+    console.log(
+      `Inserted batch of ${inserted.length} records. Total: ${totalInserted}`,
+    );
+  }
+
+  const end = performance.now();
+  console.log(
+    `Inserted ${totalInserted} record(s) in ${Math.round(end - start)}ms`,
+  );
+
+  return {
+    table: tableName,
+    recordsProcessed: totalInserted,
+    message: `${totalInserted} record(s) inserted`,
+    timestamp: new Date().toISOString(),
+  };
 }

--- a/apps/web/src/workflows/car-population/steps/process-data.test.ts
+++ b/apps/web/src/workflows/car-population/steps/process-data.test.ts
@@ -1,17 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
-
 vi.mock("@sgcarstrends/database", () => ({
-  db: {
-    selectDistinct: vi.fn().mockReturnThis(),
-    select: vi.fn().mockReturnThis(),
-    insert: vi.fn().mockReturnThis(),
-    from: vi.fn().mockReturnThis(),
-    where: vi.fn().mockReturnThis(),
-    values: vi.fn().mockReturnThis(),
-    returning: vi.fn().mockResolvedValue([]),
-  },
-  getTableName: vi.fn(() => "car_population"),
-  inArray: vi.fn(),
   carPopulation: {
     year: "year",
     make: "make",
@@ -19,154 +6,89 @@ vi.mock("@sgcarstrends/database", () => ({
   },
 }));
 
-vi.mock("@web/lib/updater/services/download-file", () => ({
-  downloadFile: vi.fn().mockResolvedValue("data.csv"),
+vi.mock("@web/lib/updater", () => ({
+  update: vi.fn(),
 }));
 
-vi.mock("@web/lib/updater/services/calculate-checksum", () => ({
-  calculateChecksum: vi.fn().mockResolvedValue("abc123"),
-}));
-
-vi.mock("@web/lib/updater/services/process-csv", () => ({
-  processCsv: vi.fn().mockResolvedValue([]),
-}));
-
-const mockGetCachedChecksum = vi.fn().mockResolvedValue(null);
-const mockCacheChecksum = vi.fn().mockResolvedValue(null);
-
-vi.mock("@web/utils/checksum", () => ({
-  Checksum: class MockChecksum {
-    getCachedChecksum = mockGetCachedChecksum;
-    cacheChecksum = mockCacheChecksum;
-  },
-}));
-
-vi.mock("@web/config/workflow", () => ({
-  AWS_LAMBDA_TEMP_DIR: "/tmp",
-}));
-
-import { db } from "@sgcarstrends/database";
-import { calculateChecksum } from "@web/lib/updater/services/calculate-checksum";
-import { downloadFile } from "@web/lib/updater/services/download-file";
-import { processCsv } from "@web/lib/updater/services/process-csv";
+import { type UpdaterResult, update } from "@web/lib/updater";
 import { updateCarPopulation } from "./process-data";
+
+const mockResult = (overrides?: Partial<UpdaterResult>): UpdaterResult => ({
+  table: "car_population",
+  recordsProcessed: 0,
+  message: "",
+  timestamp: new Date().toISOString(),
+  ...overrides,
+});
 
 describe("updateCarPopulation", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.spyOn(console, "log").mockImplementation(() => {});
   });
 
-  it("should download the correct URL", async () => {
-    vi.mocked(processCsv).mockResolvedValueOnce([]);
-    vi.mocked(db.selectDistinct).mockReturnValue({
-      from: vi.fn().mockResolvedValue([]),
-    } as unknown as ReturnType<typeof db.selectDistinct>);
+  it("should call update with correct configuration", async () => {
+    vi.mocked(update).mockResolvedValueOnce(mockResult());
 
     await updateCarPopulation();
 
-    expect(downloadFile).toHaveBeenCalledWith(
-      expect.stringContaining("Annual Car Population by Make"),
-    );
+    expect(vi.mocked(update).mock.calls[0][0]).toMatchObject({
+      url: expect.stringContaining("Annual Car Population by Make"),
+      partitionField: "year",
+      keyFields: ["year", "make", "fuelType"],
+    });
   });
 
-  it("should return early when checksum matches cached value", async () => {
-    mockGetCachedChecksum.mockResolvedValueOnce("abc123");
+  it("should return the result from update", async () => {
+    const expectedResult = mockResult({
+      recordsProcessed: 5,
+      message: "5 records inserted",
+    });
+    vi.mocked(update).mockResolvedValueOnce(expectedResult);
 
     const result = await updateCarPopulation();
 
-    expect(result.recordsProcessed).toBe(0);
-    expect(result.message).toContain("has not changed");
-    expect(processCsv).not.toHaveBeenCalled();
+    expect(update).toHaveBeenCalledTimes(1);
+    expect(result).toEqual(expectedResult);
   });
 
-  it("should process CSV with correct column mapping", async () => {
-    vi.mocked(processCsv).mockResolvedValueOnce([]);
-    vi.mocked(db.selectDistinct).mockReturnValue({
-      from: vi.fn().mockResolvedValue([]),
-    } as unknown as ReturnType<typeof db.selectDistinct>);
+  it("should configure CSV transform options with column mappings", async () => {
+    vi.mocked(update).mockResolvedValueOnce(mockResult());
 
     await updateCarPopulation();
 
-    expect(processCsv).toHaveBeenCalledWith(
-      "/tmp/data.csv",
-      expect.objectContaining({
-        columnMapping: {
-          fuel_type: "fuelType",
-        },
-      }),
-    );
+    const config = vi.mocked(update).mock.calls[0][0] as {
+      csvTransformOptions?: { columnMapping?: Record<string, string> };
+    };
+    expect(config.csvTransformOptions?.columnMapping).toEqual({
+      fuel_type: "fuelType",
+    });
   });
 
   it("should transform empty number values to 0", async () => {
-    vi.mocked(processCsv).mockResolvedValueOnce([]);
-    vi.mocked(db.selectDistinct).mockReturnValue({
-      from: vi.fn().mockResolvedValue([]),
-    } as unknown as ReturnType<typeof db.selectDistinct>);
+    vi.mocked(update).mockResolvedValueOnce(mockResult());
 
     await updateCarPopulation();
 
-    const csvOptions = vi.mocked(processCsv).mock.calls[0][1];
-    const numberTransform = csvOptions?.fields?.number;
+    const config = vi.mocked(update).mock.calls[0][0] as {
+      csvTransformOptions?: {
+        fields?: Record<string, (value: string) => number>;
+      };
+    };
+    const numberTransform = config.csvTransformOptions?.fields?.number;
 
     expect(numberTransform).toBeDefined();
     expect(numberTransform?.("")).toBe(0);
     expect(numberTransform?.("100")).toBe(100);
   });
 
-  it("should return no records when all data already exists", async () => {
-    vi.mocked(processCsv).mockResolvedValueOnce([
-      { year: "2025", make: "TOYOTA", fuelType: "Petrol", number: 100 },
-    ]);
-    vi.mocked(db.selectDistinct).mockReturnValue({
-      from: vi.fn().mockResolvedValue([{ year: "2025" }]),
-    } as unknown as ReturnType<typeof db.selectDistinct>);
-    vi.mocked(db.select).mockReturnValue({
-      from: vi.fn().mockReturnValue({
-        where: vi
-          .fn()
-          .mockResolvedValue([
-            { year: "2025", make: "TOYOTA", fuelType: "Petrol" },
-          ]),
-      }),
-    } as unknown as ReturnType<typeof db.select>);
-
-    const result = await updateCarPopulation();
-
-    expect(result.recordsProcessed).toBe(0);
-    expect(result.message).toContain("No new data");
-  });
-
-  it("should insert records from new years", async () => {
-    const newRecords = [
-      { year: "2025", make: "TOYOTA", fuelType: "Petrol", number: 200 },
-      { year: "2025", make: "BMW", fuelType: "Electric", number: 50 },
-    ];
-
-    vi.mocked(processCsv).mockResolvedValueOnce(newRecords);
-    vi.mocked(db.selectDistinct).mockReturnValue({
-      from: vi.fn().mockResolvedValue([{ year: "2024" }]),
-    } as unknown as ReturnType<typeof db.selectDistinct>);
-    vi.mocked(db.insert).mockReturnValue({
-      values: vi.fn().mockReturnValue({
-        returning: vi.fn().mockResolvedValue(newRecords),
-      }),
-    } as unknown as ReturnType<typeof db.insert>);
-
-    const result = await updateCarPopulation();
-
-    expect(result.recordsProcessed).toBe(2);
-    expect(result.message).toContain("2 record(s) inserted");
-  });
-
-  it("should calculate checksum for downloaded file", async () => {
-    vi.mocked(processCsv).mockResolvedValueOnce([]);
-    vi.mocked(db.selectDistinct).mockReturnValue({
-      from: vi.fn().mockResolvedValue([]),
-    } as unknown as ReturnType<typeof db.selectDistinct>);
+  it("should use year as partition field", async () => {
+    vi.mocked(update).mockResolvedValueOnce(mockResult());
 
     await updateCarPopulation();
 
-    expect(calculateChecksum).toHaveBeenCalledWith("/tmp/data.csv");
+    const config = vi.mocked(update).mock.calls[0][0] as {
+      partitionField?: string;
+    };
+    expect(config.partitionField).toBe("year");
   });
 });

--- a/apps/web/src/workflows/car-population/steps/process-data.ts
+++ b/apps/web/src/workflows/car-population/steps/process-data.ts
@@ -1,179 +1,22 @@
-import path from "node:path";
-import {
-  carPopulation,
-  db,
-  getTableName,
-  inArray,
-} from "@sgcarstrends/database";
+import { carPopulation } from "@sgcarstrends/database";
 import type { CarPopulation } from "@sgcarstrends/types";
-import { createUniqueKey } from "@sgcarstrends/utils";
-import { AWS_LAMBDA_TEMP_DIR } from "@web/config/workflow";
-import type { UpdaterResult } from "@web/lib/updater";
-import { calculateChecksum } from "@web/lib/updater/services/calculate-checksum";
-import { downloadFile } from "@web/lib/updater/services/download-file";
-import { processCsv } from "@web/lib/updater/services/process-csv";
-import { Checksum } from "@web/utils/checksum";
+import { update } from "@web/lib/updater";
 
 const CAR_POPULATION_URL =
   "https://datamall.lta.gov.sg/content/dam/datamall/datasets/Facts_Figures/Vehicle Population/Annual Car Population by Make.zip";
 
-const KEY_FIELDS: Array<keyof CarPopulation> = ["year", "make", "fuelType"];
-
-const BATCH_SIZE = 5000;
-
-export async function updateCarPopulation(): Promise<UpdaterResult> {
-  const tableName = getTableName(carPopulation);
-  const checksum = new Checksum();
-
-  // Download and extract
-  const extractedFileName = await downloadFile(CAR_POPULATION_URL);
-  const destinationPath = path.join(AWS_LAMBDA_TEMP_DIR, extractedFileName);
-  console.log("Destination path:", destinationPath);
-
-  // Calculate and verify checksum
-  const fileChecksum = await calculateChecksum(destinationPath);
-  console.log("Checksum:", fileChecksum);
-
-  const cachedChecksum = await checksum.getCachedChecksum(extractedFileName);
-  console.log("Cached checksum:", cachedChecksum);
-
-  if (!cachedChecksum) {
-    console.log("No cached checksum found. This might be the first run.");
-    await checksum.cacheChecksum(extractedFileName, fileChecksum);
-  } else if (cachedChecksum === fileChecksum) {
-    console.log(
-      `File has not changed since last update (Checksum: ${fileChecksum})`,
-    );
-    return {
-      table: tableName,
-      recordsProcessed: 0,
-      message: "File has not changed since last update",
-      timestamp: new Date().toISOString(),
-    };
-  } else {
-    await checksum.cacheChecksum(extractedFileName, fileChecksum);
-    console.log("Checksum has been changed.");
-  }
-
-  // Process CSV with column mapping
-  const processedData = await processCsv<CarPopulation>(destinationPath, {
-    columnMapping: {
-      fuel_type: "fuelType",
-    },
-    fields: {
-      number: (value: string) => (value === "" ? 0 : Number(value)),
+export const updateCarPopulation = () =>
+  update<CarPopulation>({
+    table: carPopulation,
+    url: CAR_POPULATION_URL,
+    partitionField: "year",
+    keyFields: ["year", "make", "fuelType"],
+    csvTransformOptions: {
+      columnMapping: {
+        fuel_type: "fuelType",
+      },
+      fields: {
+        number: (value: string) => (value === "" ? 0 : Number(value)),
+      },
     },
   });
-
-  // Year-based deduplication
-  const incomingYears = new Set(processedData.map((record) => record.year));
-
-  const existingYearsQuery = await db
-    .selectDistinct({ year: carPopulation.year })
-    .from(carPopulation);
-  const existingYears = new Set(existingYearsQuery.map((r) => r.year));
-
-  const newYears = incomingYears.difference(existingYears);
-
-  console.log(
-    `Year analysis: ${incomingYears.size} incoming, ${existingYears.size} existing, ${newYears.size} new`,
-  );
-
-  // Records from brand new years skip key comparison
-  const recordsFromNewYears: CarPopulation[] = [];
-  const recordsFromOverlappingYears: CarPopulation[] = [];
-
-  for (const record of processedData) {
-    if (newYears.has(record.year)) {
-      recordsFromNewYears.push(record);
-    } else {
-      recordsFromOverlappingYears.push(record);
-    }
-  }
-
-  console.log(
-    `Records: ${recordsFromNewYears.length} from new years, ${recordsFromOverlappingYears.length} from overlapping years`,
-  );
-
-  // Key-level comparison for overlapping years
-  let newRecordsFromOverlapping: CarPopulation[] = [];
-
-  if (recordsFromOverlappingYears.length > 0) {
-    const overlappingYears = incomingYears.intersection(existingYears);
-
-    const existingKeysQuery = await db
-      .select({
-        year: carPopulation.year,
-        make: carPopulation.make,
-        fuelType: carPopulation.fuelType,
-      })
-      .from(carPopulation)
-      .where(inArray(carPopulation.year, [...overlappingYears]));
-
-    const existingKeys = new Set(
-      existingKeysQuery.map((record) => createUniqueKey(record, KEY_FIELDS)),
-    );
-
-    const incomingKeys = new Set(
-      recordsFromOverlappingYears.map((record) =>
-        createUniqueKey(
-          record as unknown as Record<string, unknown>,
-          KEY_FIELDS,
-        ),
-      ),
-    );
-
-    if (incomingKeys.isSubsetOf(existingKeys)) {
-      console.log(
-        "Early exit: all records from overlapping years already exist",
-      );
-    } else {
-      newRecordsFromOverlapping = recordsFromOverlappingYears.filter(
-        (record) => {
-          const identifier = createUniqueKey(
-            record as unknown as Record<string, unknown>,
-            KEY_FIELDS,
-          );
-          return !existingKeys.has(identifier);
-        },
-      );
-    }
-  }
-
-  const newRecords = [...recordsFromNewYears, ...newRecordsFromOverlapping];
-
-  if (newRecords.length === 0) {
-    return {
-      table: tableName,
-      recordsProcessed: 0,
-      message:
-        "No new data to insert. The provided data matches the existing records.",
-      timestamp: new Date().toISOString(),
-    };
-  }
-
-  // Batch insert
-  let totalInserted = 0;
-  const start = performance.now();
-
-  for (let i = 0; i < newRecords.length; i += BATCH_SIZE) {
-    const batch = newRecords.slice(i, i + BATCH_SIZE);
-    const inserted = await db.insert(carPopulation).values(batch).returning();
-    totalInserted += inserted.length;
-    console.log(
-      `Inserted batch of ${inserted.length} records. Total: ${totalInserted}`,
-    );
-  }
-
-  const end = performance.now();
-  console.log(
-    `Inserted ${totalInserted} record(s) in ${Math.round(end - start)}ms`,
-  );
-
-  return {
-    table: tableName,
-    recordsProcessed: totalInserted,
-    message: `${totalInserted} record(s) inserted`,
-    timestamp: new Date().toISOString(),
-  };
-}

--- a/apps/web/src/workflows/cars/steps/process-data.ts
+++ b/apps/web/src/workflows/cars/steps/process-data.ts
@@ -2,7 +2,7 @@ import { cars } from "@sgcarstrends/database";
 import type { Car } from "@sgcarstrends/types";
 import { cleanSpecialChars } from "@sgcarstrends/utils";
 import { LTA_DATAMALL_BASE_URL } from "@web/config/workflow";
-import { Updater } from "@web/lib/updater";
+import { update } from "@web/lib/updater";
 
 export const updateCars = () => {
   const filename = "Monthly New Registration of Cars by Make.zip";
@@ -14,7 +14,7 @@ export const updateCars = () => {
     "vehicleType",
   ];
 
-  const updater = new Updater<Car>({
+  return update<Car>({
     table: cars,
     url,
     keyFields,
@@ -33,6 +33,4 @@ export const updateCars = () => {
       },
     },
   });
-
-  return updater.update();
 };

--- a/apps/web/src/workflows/coe/steps/process-data.ts
+++ b/apps/web/src/workflows/coe/steps/process-data.ts
@@ -1,7 +1,7 @@
 import { coe, pqp } from "@sgcarstrends/database";
 import type { COE, PQP } from "@sgcarstrends/types";
 import { LTA_DATAMALL_BASE_URL } from "@web/config/workflow";
-import { Updater } from "@web/lib/updater";
+import { update } from "@web/lib/updater";
 
 export const updateCoe = async () => {
   const filename = "COE Bidding Results.zip";
@@ -24,7 +24,7 @@ export const updateCoe = async () => {
     "premium",
   ];
 
-  const coeUpdater = new Updater<COE>({
+  const coeResult = await update<COE>({
     table: coe,
     url,
     csvFile: "M11-coe_results.csv",
@@ -41,15 +41,13 @@ export const updateCoe = async () => {
       ),
     },
   });
-
-  const coeResult = await coeUpdater.update();
   console.log("[COE]", coeResult);
 
   // Update COE PQP (Prevailing Quota Premium)
   const pqpKeyFields: Array<keyof PQP> = ["month", "vehicleClass", "pqp"];
   const pqpParseNumericFields: Array<keyof PQP> = ["pqp"];
 
-  const pqpUpdater = new Updater<PQP>({
+  const pqpResult = await update<PQP>({
     table: pqp,
     url,
     csvFile: "M11-coe_results_pqp.csv",
@@ -63,8 +61,6 @@ export const updateCoe = async () => {
       ),
     },
   });
-
-  const pqpResult = await pqpUpdater.update();
   console.log("[COE PQP]", pqpResult);
 
   return coeResult;

--- a/apps/web/src/workflows/deregistrations/steps/process-data.ts
+++ b/apps/web/src/workflows/deregistrations/steps/process-data.ts
@@ -1,7 +1,7 @@
 import { deregistrations } from "@sgcarstrends/database";
 import type { Deregistration } from "@sgcarstrends/types";
 import { LTA_DATAMALL_BASE_URL } from "@web/config/workflow";
-import { Updater } from "@web/lib/updater";
+import { update } from "@web/lib/updater";
 
 export const updateDeregistration = () => {
   const filename =
@@ -9,7 +9,7 @@ export const updateDeregistration = () => {
   const url = `${LTA_DATAMALL_BASE_URL}/${filename}`;
   const keyFields: Array<keyof Deregistration> = ["month", "category"];
 
-  const updater = new Updater<Deregistration>({
+  return update<Deregistration>({
     table: deregistrations,
     url,
     keyFields,
@@ -19,6 +19,4 @@ export const updateDeregistration = () => {
       },
     },
   });
-
-  return updater.update();
 };

--- a/apps/web/src/workflows/vehicle-population/steps/process-data.test.ts
+++ b/apps/web/src/workflows/vehicle-population/steps/process-data.test.ts
@@ -1,17 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
-
 vi.mock("@sgcarstrends/database", () => ({
-  db: {
-    selectDistinct: vi.fn().mockReturnThis(),
-    select: vi.fn().mockReturnThis(),
-    insert: vi.fn().mockReturnThis(),
-    from: vi.fn().mockReturnThis(),
-    where: vi.fn().mockReturnThis(),
-    values: vi.fn().mockReturnThis(),
-    returning: vi.fn().mockResolvedValue([]),
-  },
-  getTableName: vi.fn(() => "vehicle_population"),
-  inArray: vi.fn(),
   vehiclePopulation: {
     year: "year",
     category: "category",
@@ -19,155 +6,90 @@ vi.mock("@sgcarstrends/database", () => ({
   },
 }));
 
-vi.mock("@web/lib/updater/services/download-file", () => ({
-  downloadFile: vi.fn().mockResolvedValue("data.csv"),
+vi.mock("@web/lib/updater", () => ({
+  update: vi.fn(),
 }));
 
-vi.mock("@web/lib/updater/services/calculate-checksum", () => ({
-  calculateChecksum: vi.fn().mockResolvedValue("abc123"),
-}));
-
-vi.mock("@web/lib/updater/services/process-csv", () => ({
-  processCsv: vi.fn().mockResolvedValue([]),
-}));
-
-const mockGetCachedChecksum = vi.fn().mockResolvedValue(null);
-const mockCacheChecksum = vi.fn().mockResolvedValue(null);
-
-vi.mock("@web/utils/checksum", () => ({
-  Checksum: class MockChecksum {
-    getCachedChecksum = mockGetCachedChecksum;
-    cacheChecksum = mockCacheChecksum;
-  },
-}));
-
-vi.mock("@web/config/workflow", () => ({
-  AWS_LAMBDA_TEMP_DIR: "/tmp",
-}));
-
-import { db } from "@sgcarstrends/database";
-import { calculateChecksum } from "@web/lib/updater/services/calculate-checksum";
-import { downloadFile } from "@web/lib/updater/services/download-file";
-import { processCsv } from "@web/lib/updater/services/process-csv";
+import { type UpdaterResult, update } from "@web/lib/updater";
 import { updateVehiclePopulation } from "./process-data";
+
+const mockResult = (overrides?: Partial<UpdaterResult>): UpdaterResult => ({
+  table: "vehicle_population",
+  recordsProcessed: 0,
+  message: "",
+  timestamp: new Date().toISOString(),
+  ...overrides,
+});
 
 describe("updateVehiclePopulation", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.spyOn(console, "log").mockImplementation(() => {});
   });
 
-  it("should download the correct URL", async () => {
-    vi.mocked(processCsv).mockResolvedValueOnce([]);
-    vi.mocked(db.selectDistinct).mockReturnValue({
-      from: vi.fn().mockResolvedValue([]),
-    } as unknown as ReturnType<typeof db.selectDistinct>);
+  it("should call update with correct configuration", async () => {
+    vi.mocked(update).mockResolvedValueOnce(mockResult());
 
     await updateVehiclePopulation();
 
-    expect(downloadFile).toHaveBeenCalledWith(
-      expect.stringContaining("Annual Motor Vehicle Population"),
-    );
+    expect(vi.mocked(update).mock.calls[0][0]).toMatchObject({
+      url: expect.stringContaining("Annual Motor Vehicle Population"),
+      partitionField: "year",
+      keyFields: ["year", "category", "fuelType"],
+    });
   });
 
-  it("should return early when checksum matches cached value", async () => {
-    mockGetCachedChecksum.mockResolvedValueOnce("abc123");
+  it("should return the result from update", async () => {
+    const expectedResult = mockResult({
+      recordsProcessed: 5,
+      message: "5 records inserted",
+    });
+    vi.mocked(update).mockResolvedValueOnce(expectedResult);
 
     const result = await updateVehiclePopulation();
 
-    expect(result.recordsProcessed).toBe(0);
-    expect(result.message).toContain("has not changed");
-    expect(processCsv).not.toHaveBeenCalled();
+    expect(update).toHaveBeenCalledTimes(1);
+    expect(result).toEqual(expectedResult);
   });
 
-  it("should process CSV with correct column mapping", async () => {
-    vi.mocked(processCsv).mockResolvedValueOnce([]);
-    vi.mocked(db.selectDistinct).mockReturnValue({
-      from: vi.fn().mockResolvedValue([]),
-    } as unknown as ReturnType<typeof db.selectDistinct>);
+  it("should configure CSV transform options with column mappings", async () => {
+    vi.mocked(update).mockResolvedValueOnce(mockResult());
 
     await updateVehiclePopulation();
 
-    expect(processCsv).toHaveBeenCalledWith(
-      "/tmp/data.csv",
-      expect.objectContaining({
-        columnMapping: {
-          type: "category",
-          engine: "fuelType",
-        },
-      }),
-    );
+    const config = vi.mocked(update).mock.calls[0][0] as {
+      csvTransformOptions?: { columnMapping?: Record<string, string> };
+    };
+    expect(config.csvTransformOptions?.columnMapping).toEqual({
+      type: "category",
+      engine: "fuelType",
+    });
   });
 
   it("should transform empty number values to 0", async () => {
-    vi.mocked(processCsv).mockResolvedValueOnce([]);
-    vi.mocked(db.selectDistinct).mockReturnValue({
-      from: vi.fn().mockResolvedValue([]),
-    } as unknown as ReturnType<typeof db.selectDistinct>);
+    vi.mocked(update).mockResolvedValueOnce(mockResult());
 
     await updateVehiclePopulation();
 
-    const csvOptions = vi.mocked(processCsv).mock.calls[0][1];
-    const numberTransform = csvOptions?.fields?.number;
+    const config = vi.mocked(update).mock.calls[0][0] as {
+      csvTransformOptions?: {
+        fields?: Record<string, (value: string) => number>;
+      };
+    };
+    const numberTransform = config.csvTransformOptions?.fields?.number;
 
     expect(numberTransform).toBeDefined();
     expect(numberTransform?.("")).toBe(0);
     expect(numberTransform?.("100")).toBe(100);
   });
 
-  it("should return no records when all data already exists", async () => {
-    vi.mocked(processCsv).mockResolvedValueOnce([
-      { year: "2023", category: "Cars", fuelType: "Petrol", number: 100 },
-    ]);
-    vi.mocked(db.selectDistinct).mockReturnValue({
-      from: vi.fn().mockResolvedValue([{ year: "2023" }]),
-    } as unknown as ReturnType<typeof db.selectDistinct>);
-    vi.mocked(db.select).mockReturnValue({
-      from: vi.fn().mockReturnValue({
-        where: vi
-          .fn()
-          .mockResolvedValue([
-            { year: "2023", category: "Cars", fuelType: "Petrol" },
-          ]),
-      }),
-    } as unknown as ReturnType<typeof db.select>);
-
-    const result = await updateVehiclePopulation();
-
-    expect(result.recordsProcessed).toBe(0);
-    expect(result.message).toContain("No new data");
-  });
-
-  it("should insert records from new years", async () => {
-    const newRecords = [
-      { year: "2024", category: "Cars", fuelType: "Petrol", number: 200 },
-      { year: "2024", category: "Cars", fuelType: "Electric", number: 50 },
-    ];
-
-    vi.mocked(processCsv).mockResolvedValueOnce(newRecords);
-    vi.mocked(db.selectDistinct).mockReturnValue({
-      from: vi.fn().mockResolvedValue([{ year: "2023" }]),
-    } as unknown as ReturnType<typeof db.selectDistinct>);
-    vi.mocked(db.insert).mockReturnValue({
-      values: vi.fn().mockReturnValue({
-        returning: vi.fn().mockResolvedValue(newRecords),
-      }),
-    } as unknown as ReturnType<typeof db.insert>);
-
-    const result = await updateVehiclePopulation();
-
-    expect(result.recordsProcessed).toBe(2);
-    expect(result.message).toContain("2 record(s) inserted");
-  });
-
-  it("should calculate checksum for downloaded file", async () => {
-    vi.mocked(processCsv).mockResolvedValueOnce([]);
-    vi.mocked(db.selectDistinct).mockReturnValue({
-      from: vi.fn().mockResolvedValue([]),
-    } as unknown as ReturnType<typeof db.selectDistinct>);
+  it("should use year as partition field", async () => {
+    vi.mocked(update).mockResolvedValueOnce(mockResult());
 
     await updateVehiclePopulation();
 
-    expect(calculateChecksum).toHaveBeenCalledWith("/tmp/data.csv");
+    const config = vi.mocked(update).mock.calls[0][0] as {
+      partitionField?: string;
+    };
+    expect(config.partitionField).toBe("year");
   });
 });

--- a/apps/web/src/workflows/vehicle-population/steps/process-data.ts
+++ b/apps/web/src/workflows/vehicle-population/steps/process-data.ts
@@ -1,187 +1,23 @@
-import path from "node:path";
-import {
-  db,
-  getTableName,
-  inArray,
-  vehiclePopulation,
-} from "@sgcarstrends/database";
+import { vehiclePopulation } from "@sgcarstrends/database";
 import type { VehiclePopulation } from "@sgcarstrends/types";
-import { createUniqueKey } from "@sgcarstrends/utils";
-import { AWS_LAMBDA_TEMP_DIR } from "@web/config/workflow";
-import type { UpdaterResult } from "@web/lib/updater";
-import { calculateChecksum } from "@web/lib/updater/services/calculate-checksum";
-import { downloadFile } from "@web/lib/updater/services/download-file";
-import { processCsv } from "@web/lib/updater/services/process-csv";
-import { Checksum } from "@web/utils/checksum";
+import { update } from "@web/lib/updater";
 
 const VEHICLE_POPULATION_URL =
   "https://datamall.lta.gov.sg/content/dam/datamall/datasets/Facts_Figures/Vehicle Population/Annual Motor Vehicle Population by Type of Fuel Used.zip";
 
-const KEY_FIELDS: Array<keyof VehiclePopulation> = [
-  "year",
-  "category",
-  "fuelType",
-];
-
-const BATCH_SIZE = 5000;
-
-export async function updateVehiclePopulation(): Promise<UpdaterResult> {
-  const tableName = getTableName(vehiclePopulation);
-  const checksum = new Checksum();
-
-  // Download and extract
-  const extractedFileName = await downloadFile(VEHICLE_POPULATION_URL);
-  const destinationPath = path.join(AWS_LAMBDA_TEMP_DIR, extractedFileName);
-  console.log("Destination path:", destinationPath);
-
-  // Calculate and verify checksum
-  const fileChecksum = await calculateChecksum(destinationPath);
-  console.log("Checksum:", fileChecksum);
-
-  const cachedChecksum = await checksum.getCachedChecksum(extractedFileName);
-  console.log("Cached checksum:", cachedChecksum);
-
-  if (!cachedChecksum) {
-    console.log("No cached checksum found. This might be the first run.");
-    await checksum.cacheChecksum(extractedFileName, fileChecksum);
-  } else if (cachedChecksum === fileChecksum) {
-    console.log(
-      `File has not changed since last update (Checksum: ${fileChecksum})`,
-    );
-    return {
-      table: tableName,
-      recordsProcessed: 0,
-      message: "File has not changed since last update",
-      timestamp: new Date().toISOString(),
-    };
-  } else {
-    await checksum.cacheChecksum(extractedFileName, fileChecksum);
-    console.log("Checksum has been changed.");
-  }
-
-  // Process CSV with column mapping
-  const processedData = await processCsv<VehiclePopulation>(destinationPath, {
-    columnMapping: {
-      type: "category",
-      engine: "fuelType",
-    },
-    fields: {
-      number: (value: string) => (value === "" ? 0 : Number(value)),
+export const updateVehiclePopulation = () =>
+  update<VehiclePopulation>({
+    table: vehiclePopulation,
+    url: VEHICLE_POPULATION_URL,
+    partitionField: "year",
+    keyFields: ["year", "category", "fuelType"],
+    csvTransformOptions: {
+      columnMapping: {
+        type: "category",
+        engine: "fuelType",
+      },
+      fields: {
+        number: (value: string) => (value === "" ? 0 : Number(value)),
+      },
     },
   });
-
-  // Year-based deduplication
-  const incomingYears = new Set(processedData.map((record) => record.year));
-
-  const existingYearsQuery = await db
-    .selectDistinct({ year: vehiclePopulation.year })
-    .from(vehiclePopulation);
-  const existingYears = new Set(existingYearsQuery.map((r) => r.year));
-
-  const newYears = incomingYears.difference(existingYears);
-
-  console.log(
-    `Year analysis: ${incomingYears.size} incoming, ${existingYears.size} existing, ${newYears.size} new`,
-  );
-
-  // Records from brand new years skip key comparison
-  const recordsFromNewYears: VehiclePopulation[] = [];
-  const recordsFromOverlappingYears: VehiclePopulation[] = [];
-
-  for (const record of processedData) {
-    if (newYears.has(record.year)) {
-      recordsFromNewYears.push(record);
-    } else {
-      recordsFromOverlappingYears.push(record);
-    }
-  }
-
-  console.log(
-    `Records: ${recordsFromNewYears.length} from new years, ${recordsFromOverlappingYears.length} from overlapping years`,
-  );
-
-  // Key-level comparison for overlapping years
-  let newRecordsFromOverlapping: VehiclePopulation[] = [];
-
-  if (recordsFromOverlappingYears.length > 0) {
-    const overlappingYears = incomingYears.intersection(existingYears);
-
-    const existingKeysQuery = await db
-      .select({
-        year: vehiclePopulation.year,
-        category: vehiclePopulation.category,
-        fuelType: vehiclePopulation.fuelType,
-      })
-      .from(vehiclePopulation)
-      .where(inArray(vehiclePopulation.year, [...overlappingYears]));
-
-    const existingKeys = new Set(
-      existingKeysQuery.map((record) => createUniqueKey(record, KEY_FIELDS)),
-    );
-
-    const incomingKeys = new Set(
-      recordsFromOverlappingYears.map((record) =>
-        createUniqueKey(
-          record as unknown as Record<string, unknown>,
-          KEY_FIELDS,
-        ),
-      ),
-    );
-
-    if (incomingKeys.isSubsetOf(existingKeys)) {
-      console.log(
-        "Early exit: all records from overlapping years already exist",
-      );
-    } else {
-      newRecordsFromOverlapping = recordsFromOverlappingYears.filter(
-        (record) => {
-          const identifier = createUniqueKey(
-            record as unknown as Record<string, unknown>,
-            KEY_FIELDS,
-          );
-          return !existingKeys.has(identifier);
-        },
-      );
-    }
-  }
-
-  const newRecords = [...recordsFromNewYears, ...newRecordsFromOverlapping];
-
-  if (newRecords.length === 0) {
-    return {
-      table: tableName,
-      recordsProcessed: 0,
-      message:
-        "No new data to insert. The provided data matches the existing records.",
-      timestamp: new Date().toISOString(),
-    };
-  }
-
-  // Batch insert
-  let totalInserted = 0;
-  const start = performance.now();
-
-  for (let i = 0; i < newRecords.length; i += BATCH_SIZE) {
-    const batch = newRecords.slice(i, i + BATCH_SIZE);
-    const inserted = await db
-      .insert(vehiclePopulation)
-      .values(batch)
-      .returning();
-    totalInserted += inserted.length;
-    console.log(
-      `Inserted batch of ${inserted.length} records. Total: ${totalInserted}`,
-    );
-  }
-
-  const end = performance.now();
-  console.log(
-    `Inserted ${totalInserted} record(s) in ${Math.round(end - start)}ms`,
-  );
-
-  return {
-    table: tableName,
-    recordsProcessed: totalInserted,
-    message: `${totalInserted} record(s) inserted`,
-    timestamp: new Date().toISOString(),
-  };
-}


### PR DESCRIPTION
Closes #698

## Summary

- Convert `Updater` class to `update()` function with configurable `partitionField` option (defaults to `"month"`)
- Replace ~340 lines of duplicated standalone logic in `vehicle-population` and `car-population` with shared `update()` calls using `partitionField: "year"`
- Migrate all 5 workflow consumers (cars, COE, deregistrations, vehicle-population, car-population) to the new function API