### PR TITLE
Fix annual view tabs not updating on click

### DIFF
--- a/apps/web/src/app/(main)/(dashboard)/annual/components/annual-view-tabs.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/annual/components/annual-view-tabs.tsx
@@ -2,22 +2,21 @@
 
 import { Tab, Tabs } from "@heroui/tabs";
 import {
-  searchParams,
+  VIEWS,
   type View,
 } from "@web/app/(main)/(dashboard)/annual/search-params";
-import { useQueryStates } from "nuqs";
+import { parseAsStringLiteral, useQueryState } from "nuqs";
 
-interface AnnualViewTabsProps {
-  currentView: View;
-}
-
-export function AnnualViewTabs({ currentView }: AnnualViewTabsProps) {
-  const [, setSearchParams] = useQueryStates(searchParams);
+export function AnnualViewTabs() {
+  const [view, setView] = useQueryState(
+    "view",
+    parseAsStringLiteral(VIEWS).withDefault("fuel-type"),
+  );
 
   return (
     <Tabs
-      selectedKey={currentView}
-      onSelectionChange={(key) => setSearchParams({ view: key as View })}
+      selectedKey={view}
+      onSelectionChange={(key) => setView(key as View)}
       variant="underlined"
       aria-label="Annual data view"
     >

--- a/apps/web/src/app/(main)/(dashboard)/annual/page.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/annual/page.tsx
@@ -64,7 +64,7 @@ interface PageProps {
   searchParams: Promise<SearchParams>;
 }
 
-async function AnnualPage({ searchParams: searchParamsPromise }: PageProps) {
+async function AnnualPage({ searchParams }: PageProps) {
   return (
     <>
       <StructuredData data={structuredData} />
@@ -78,17 +78,17 @@ async function AnnualPage({ searchParams: searchParamsPromise }: PageProps) {
           }
           meta={
             <Suspense fallback={<SkeletonCard className="h-10 w-40" />}>
-              <AnnualHeaderMeta searchParams={searchParamsPromise} />
+              <AnnualHeaderMeta searchParams={searchParams} />
             </Suspense>
           }
         />
 
-        <Suspense fallback={<SkeletonCard className="h-10 w-64" />}>
-          <AnnualViewTabsWrapper searchParams={searchParamsPromise} />
+        <Suspense>
+          <AnnualViewTabs />
         </Suspense>
 
         <Suspense fallback={<SkeletonCard className="h-[460px] w-full" />}>
-          <AnnualContent searchParams={searchParamsPromise} />
+          <AnnualContent searchParams={searchParams} />
         </Suspense>
       </section>
     </>
@@ -96,12 +96,11 @@ async function AnnualPage({ searchParams: searchParamsPromise }: PageProps) {
 }
 
 async function AnnualHeaderMeta({
-  searchParams: searchParamsPromise,
+  searchParams,
 }: {
   searchParams: Promise<SearchParams>;
 }) {
-  const { year: parsedYear, view } =
-    await loadSearchParams(searchParamsPromise);
+  const { year: parsedYear, view } = await loadSearchParams(searchParams);
 
   const availableYearsData =
     view === "make"
@@ -127,22 +126,12 @@ async function AnnualHeaderMeta({
   );
 }
 
-async function AnnualViewTabsWrapper({
-  searchParams: searchParamsPromise,
-}: {
-  searchParams: Promise<SearchParams>;
-}) {
-  const { view } = await loadSearchParams(searchParamsPromise);
-
-  return <AnnualViewTabs currentView={view} />;
-}
-
 async function AnnualContent({
-  searchParams: searchParamsPromise,
+  searchParams,
 }: {
   searchParams: Promise<SearchParams>;
 }) {
-  const { view } = await loadSearchParams(searchParamsPromise);
+  const { view } = await loadSearchParams(searchParams);
 
   if (view === "make") {
     return <ByMakeContent />;


### PR DESCRIPTION
- Use nuqs client state for `selectedKey` instead of server prop so the tab updates immediately on click