### PR TITLE
Fix annual view tabs not updating on click

### DIFF
--- a/apps/web/src/app/(main)/(dashboard)/annual/components/annual-view-tabs.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/annual/components/annual-view-tabs.tsx
@@ -12,11 +12,11 @@ interface AnnualViewTabsProps {
 }
 
 export function AnnualViewTabs({ currentView }: AnnualViewTabsProps) {
-  const [, setSearchParams] = useQueryStates(searchParams);
+  const [{ view }, setSearchParams] = useQueryStates(searchParams);
 
   return (
     <Tabs
-      selectedKey={currentView}
+      selectedKey={view ?? currentView}
       onSelectionChange={(key) => setSearchParams({ view: key as View })}
       variant="underlined"
       aria-label="Annual data view"


### PR DESCRIPTION
- Use nuqs client state for `selectedKey` instead of server prop so the tab updates immediately on click