### PR TITLE
Fix annual view tabs not switching content

### DIFF
--- a/apps/web/src/app/(main)/(dashboard)/annual/components/annual-view-tabs.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/annual/components/annual-view-tabs.tsx
@@ -6,11 +6,23 @@ import {
   type View,
 } from "@web/app/(main)/(dashboard)/annual/search-params";
 import { parseAsStringLiteral, useQueryState } from "nuqs";
+import { type ReactNode, useTransition } from "react";
 
-export function AnnualViewTabs() {
+interface AnnualViewTabsProps {
+  fuelTypeContent: ReactNode;
+  makeContent: ReactNode;
+}
+
+export function AnnualViewTabs({
+  fuelTypeContent,
+  makeContent,
+}: AnnualViewTabsProps) {
+  const [, startTransition] = useTransition();
   const [view, setView] = useQueryState(
     "view",
-    parseAsStringLiteral(VIEWS).withDefault("fuel-type"),
+    parseAsStringLiteral(VIEWS)
+      .withDefault("fuel-type")
+      .withOptions({ shallow: false, startTransition }),
   );
 
   return (
@@ -20,8 +32,12 @@ export function AnnualViewTabs() {
       variant="underlined"
       aria-label="Annual data view"
     >
-      <Tab key="fuel-type" title="By Fuel Type" />
-      <Tab key="make" title="By Make" />
+      <Tab key="fuel-type" title="By Fuel Type">
+        <div className="flex flex-col gap-10 pt-4">{fuelTypeContent}</div>
+      </Tab>
+      <Tab key="make" title="By Make">
+        <div className="flex flex-col gap-10 pt-4">{makeContent}</div>
+      </Tab>
     </Tabs>
   );
 }

--- a/apps/web/src/app/(main)/(dashboard)/annual/page.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/annual/page.tsx
@@ -83,18 +83,12 @@ async function AnnualPage({ searchParams }: PageProps) {
           }
         />
 
-        <AnnualViewTabs
-          fuelTypeContent={
-            <Suspense>
-              <ByFuelTypeContent />
-            </Suspense>
-          }
-          makeContent={
-            <Suspense>
-              <ByMakeContent />
-            </Suspense>
-          }
-        />
+        <Suspense>
+          <AnnualViewTabs
+            fuelTypeContent={<ByFuelTypeContent />}
+            makeContent={<ByMakeContent />}
+          />
+        </Suspense>
       </section>
     </>
   );

--- a/apps/web/src/app/(main)/(dashboard)/annual/page.tsx
+++ b/apps/web/src/app/(main)/(dashboard)/annual/page.tsx
@@ -83,13 +83,18 @@ async function AnnualPage({ searchParams }: PageProps) {
           }
         />
 
-        <Suspense>
-          <AnnualViewTabs />
-        </Suspense>
-
-        <Suspense fallback={<SkeletonCard className="h-[460px] w-full" />}>
-          <AnnualContent searchParams={searchParams} />
-        </Suspense>
+        <AnnualViewTabs
+          fuelTypeContent={
+            <Suspense>
+              <ByFuelTypeContent />
+            </Suspense>
+          }
+          makeContent={
+            <Suspense>
+              <ByMakeContent />
+            </Suspense>
+          }
+        />
       </section>
     </>
   );
@@ -124,20 +129,6 @@ async function AnnualHeaderMeta({
       />
     </DashboardPageMeta>
   );
-}
-
-async function AnnualContent({
-  searchParams,
-}: {
-  searchParams: Promise<SearchParams>;
-}) {
-  const { view } = await loadSearchParams(searchParams);
-
-  if (view === "make") {
-    return <ByMakeContent />;
-  }
-
-  return <ByFuelTypeContent />;
 }
 
 async function ByFuelTypeContent() {


### PR DESCRIPTION
- Use HeroUI Tabs with content panels instead of empty Tab elements with separate server-side conditional rendering
- Add nuqs `shallow: false` with `startTransition` so tab changes notify the server and update the year selector