### PR TITLE
Add dedicated Electric Vehicles page

### DIFF
--- a/apps/web/src/app/(main)/(explore)/cars/electric-vehicles/components/adoption-trend-chart.tsx
+++ b/apps/web/src/app/(main)/(explore)/cars/electric-vehicles/components/adoption-trend-chart.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import { Card, CardBody, CardFooter, CardHeader } from "@heroui/card";
+import { cn } from "@heroui/theme";
+import {
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+} from "@sgcarstrends/ui/components/chart";
+import { EV_COLORS } from "@web/app/(main)/(explore)/cars/electric-vehicles/constants";
+import Typography from "@web/components/typography";
+import {
+  CARD_PADDING,
+  CHART_CURSOR,
+  CHART_GRID,
+  CHART_HEIGHTS,
+  RADIUS,
+} from "@web/config/design-system";
+import type { EvMonthlyTrend } from "@web/queries/cars/electric-vehicles";
+import { Area, AreaChart, CartesianGrid, Legend, XAxis, YAxis } from "recharts";
+
+interface AdoptionTrendChartProps {
+  data: EvMonthlyTrend[];
+}
+
+const chartConfig = {
+  BEV: { label: "BEV (Battery Electric)", color: EV_COLORS.BEV },
+  PHEV: { label: "PHEV (Plug-In Hybrid)", color: EV_COLORS.PHEV },
+  Hybrid: { label: "Hybrid (HEV)", color: EV_COLORS.Hybrid },
+};
+
+export function AdoptionTrendChart({ data }: AdoptionTrendChartProps) {
+  const numberFormatter = new Intl.NumberFormat("en-SG");
+
+  return (
+    <Card className={cn(RADIUS.card, CARD_PADDING.standard)}>
+      <CardHeader className="flex flex-col items-start gap-2">
+        <Typography.H4>EV Adoption Trend</Typography.H4>
+        <Typography.TextSm className="text-default-500">
+          Monthly BEV, PHEV, and Hybrid registrations over time
+        </Typography.TextSm>
+      </CardHeader>
+      <CardBody>
+        <ChartContainer
+          config={chartConfig}
+          className={cn(CHART_HEIGHTS.tall, "w-full")}
+        >
+          <AreaChart data={data}>
+            <CartesianGrid {...CHART_GRID.default} />
+            <XAxis
+              dataKey="month"
+              tickLine={false}
+              axisLine={false}
+              tickMargin={8}
+              tickFormatter={(value) => {
+                const [year, month] = value.split("-");
+                return `${month}/${year.slice(2)}`;
+              }}
+              interval="preserveStartEnd"
+              minTickGap={40}
+            />
+            <YAxis
+              tickLine={false}
+              axisLine={false}
+              tickFormatter={(value) => numberFormatter.format(value)}
+              width={60}
+            />
+            <ChartTooltip
+              cursor={CHART_CURSOR.highlight}
+              content={
+                <ChartTooltipContent
+                  formatter={(value) => numberFormatter.format(value as number)}
+                />
+              }
+            />
+            <Legend />
+            <Area
+              type="monotone"
+              dataKey="Hybrid"
+              stackId="ev"
+              fill={EV_COLORS.Hybrid}
+              stroke={EV_COLORS.Hybrid}
+              fillOpacity={0.4}
+            />
+            <Area
+              type="monotone"
+              dataKey="PHEV"
+              stackId="ev"
+              fill={EV_COLORS.PHEV}
+              stroke={EV_COLORS.PHEV}
+              fillOpacity={0.4}
+            />
+            <Area
+              type="monotone"
+              dataKey="BEV"
+              stackId="ev"
+              fill={EV_COLORS.BEV}
+              stroke={EV_COLORS.BEV}
+              fillOpacity={0.4}
+            />
+          </AreaChart>
+        </ChartContainer>
+      </CardBody>
+      <CardFooter>
+        <Typography.TextSm className="text-default-500">
+          Stacked area chart showing combined electrified vehicle registrations.
+          BEV = Battery Electric, PHEV = Plug-In Hybrid, Hybrid = Conventional
+          Hybrid.
+        </Typography.TextSm>
+      </CardFooter>
+    </Card>
+  );
+}

--- a/apps/web/src/app/(main)/(explore)/cars/electric-vehicles/components/ev-metrics.tsx
+++ b/apps/web/src/app/(main)/(explore)/cars/electric-vehicles/components/ev-metrics.tsx
@@ -1,0 +1,60 @@
+import { Card, CardBody, CardHeader } from "@heroui/card";
+import { cn } from "@heroui/theme";
+import { formatDateToMonthYear } from "@sgcarstrends/utils";
+import Typography from "@web/components/typography";
+import { CARD_PADDING, RADIUS } from "@web/config/design-system";
+import type { EvLatestSummary } from "@web/queries/cars/electric-vehicles";
+
+interface EvMetricsProps {
+  summary: EvLatestSummary;
+}
+
+export function EvMetrics({ summary }: EvMetricsProps) {
+  const numberFormatter = new Intl.NumberFormat("en-SG");
+
+  const metrics = [
+    {
+      title: "Total EV Registrations",
+      value: numberFormatter.format(summary.totalEv),
+      description: formatDateToMonthYear(summary.month),
+    },
+    {
+      title: "EV Market Share",
+      value: `${summary.evSharePercent.toFixed(1)}%`,
+      description: "of all new registrations",
+    },
+    {
+      title: "BEV Count",
+      value: numberFormatter.format(summary.bevCount),
+      description: "Battery electric vehicles",
+    },
+    {
+      title: "Top EV Make",
+      value: summary.topMake,
+      description: "Most registered EV brand",
+    },
+  ];
+
+  return (
+    <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-4">
+      {metrics.map((metric) => (
+        <Card
+          key={metric.title}
+          className={cn(RADIUS.card, CARD_PADDING.standard)}
+        >
+          <CardHeader>
+            <Typography.H4>{metric.title}</Typography.H4>
+          </CardHeader>
+          <CardBody className="flex flex-col gap-2">
+            <span className="font-semibold text-4xl text-primary tabular-nums">
+              {metric.value}
+            </span>
+            <Typography.TextSm className="text-default-500">
+              {metric.description}
+            </Typography.TextSm>
+          </CardBody>
+        </Card>
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/app/(main)/(explore)/cars/electric-vehicles/components/make-table.tsx
+++ b/apps/web/src/app/(main)/(explore)/cars/electric-vehicles/components/make-table.tsx
@@ -1,0 +1,149 @@
+"use client";
+
+import { Card, CardBody, CardHeader } from "@heroui/card";
+import { Pagination } from "@heroui/pagination";
+import {
+  type SortDescriptor,
+  Table,
+  TableBody,
+  TableCell,
+  TableColumn,
+  TableHeader,
+  TableRow,
+} from "@heroui/table";
+import { cn } from "@heroui/theme";
+import Typography from "@web/components/typography";
+import { CARD_PADDING, RADIUS } from "@web/config/design-system";
+import type { EvMakeDetail } from "@web/queries/cars";
+import { type Key, useCallback, useMemo, useState } from "react";
+
+interface MakeTableProps {
+  data: EvMakeDetail[];
+  month: string;
+}
+
+const columns = [
+  { key: "rank", label: "#" },
+  { key: "make", label: "Make" },
+  { key: "bev", label: "BEV" },
+  { key: "phev", label: "PHEV" },
+  { key: "hybrid", label: "Hybrid" },
+  { key: "total", label: "Total" },
+];
+
+const ROWS_PER_PAGE = 20;
+
+export function MakeTable({ data, month }: MakeTableProps) {
+  const numberFormatter = new Intl.NumberFormat("en-SG");
+  const [page, setPage] = useState(1);
+  const [sortDescriptor, setSortDescriptor] = useState<SortDescriptor>({
+    column: "total",
+    direction: "descending",
+  });
+
+  const rankedData = useMemo(() => {
+    return data.map((item, index) => ({
+      ...item,
+      rank: index + 1,
+    }));
+  }, [data]);
+
+  const sortedData = useMemo(() => {
+    return [...rankedData].sort((a, b) => {
+      const column = sortDescriptor.column as keyof typeof a;
+      const first = a[column];
+      const second = b[column];
+
+      if (typeof first === "number" && typeof second === "number") {
+        return sortDescriptor.direction === "ascending"
+          ? first - second
+          : second - first;
+      }
+
+      return sortDescriptor.direction === "ascending"
+        ? String(first).localeCompare(String(second))
+        : String(second).localeCompare(String(first));
+    });
+  }, [rankedData, sortDescriptor]);
+
+  const pages = Math.ceil(sortedData.length / ROWS_PER_PAGE);
+  const paginatedData = useMemo(() => {
+    const start = (page - 1) * ROWS_PER_PAGE;
+    return sortedData.slice(start, start + ROWS_PER_PAGE);
+  }, [sortedData, page]);
+
+  const renderCell = useCallback(
+    (item: (typeof rankedData)[0], columnKey: Key) => {
+      switch (columnKey) {
+        case "rank":
+          return item.rank;
+        case "make":
+          return item.make;
+        case "bev":
+          return numberFormatter.format(item.bev);
+        case "phev":
+          return numberFormatter.format(item.phev);
+        case "hybrid":
+          return numberFormatter.format(item.hybrid);
+        case "total":
+          return numberFormatter.format(item.total);
+        default:
+          return null;
+      }
+    },
+    [numberFormatter],
+  );
+
+  return (
+    <Card className={cn(RADIUS.card, CARD_PADDING.standard)}>
+      <CardHeader className="flex flex-col items-start gap-2">
+        <Typography.H4>EV Registrations by Make</Typography.H4>
+        <Typography.TextSm className="text-default-500">
+          {data.length} makes with EV registrations in {month}
+        </Typography.TextSm>
+      </CardHeader>
+      <CardBody>
+        <Table
+          aria-label="EV registrations by make"
+          sortDescriptor={sortDescriptor}
+          onSortChange={setSortDescriptor}
+          bottomContent={
+            pages > 1 ? (
+              <div className="flex w-full justify-center">
+                <Pagination
+                  isCompact
+                  showControls
+                  showShadow
+                  page={page}
+                  total={pages}
+                  onChange={setPage}
+                />
+              </div>
+            ) : null
+          }
+          bottomContentPlacement="outside"
+        >
+          <TableHeader columns={columns}>
+            {(column) => (
+              <TableColumn
+                key={column.key}
+                allowsSorting={column.key !== "rank"}
+              >
+                {column.label}
+              </TableColumn>
+            )}
+          </TableHeader>
+          <TableBody items={paginatedData}>
+            {(item) => (
+              <TableRow key={item.make}>
+                {(columnKey) => (
+                  <TableCell>{renderCell(item, columnKey)}</TableCell>
+                )}
+              </TableRow>
+            )}
+          </TableBody>
+        </Table>
+      </CardBody>
+    </Card>
+  );
+}

--- a/apps/web/src/app/(main)/(explore)/cars/electric-vehicles/components/market-share-chart.tsx
+++ b/apps/web/src/app/(main)/(explore)/cars/electric-vehicles/components/market-share-chart.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import { Card, CardBody, CardFooter, CardHeader } from "@heroui/card";
+import { cn } from "@heroui/theme";
+import {
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+} from "@sgcarstrends/ui/components/chart";
+import Typography from "@web/components/typography";
+import {
+  CARD_PADDING,
+  CHART_CURSOR,
+  CHART_GRID,
+  CHART_HEIGHTS,
+  RADIUS,
+} from "@web/config/design-system";
+import type { EvMarketShare } from "@web/queries/cars/electric-vehicles";
+import { Area, AreaChart, CartesianGrid, XAxis, YAxis } from "recharts";
+
+interface MarketShareChartProps {
+  data: EvMarketShare[];
+}
+
+const chartConfig = {
+  evShare: { label: "EV Market Share (%)", color: "var(--chart-1)" },
+};
+
+export function MarketShareChart({ data }: MarketShareChartProps) {
+  return (
+    <Card className={cn(RADIUS.card, CARD_PADDING.standard)}>
+      <CardHeader className="flex flex-col items-start gap-2">
+        <Typography.H4>EV Market Share</Typography.H4>
+        <Typography.TextSm className="text-default-500">
+          Percentage of electrified vehicles among all new registrations
+        </Typography.TextSm>
+      </CardHeader>
+      <CardBody>
+        <ChartContainer
+          config={chartConfig}
+          className={cn(CHART_HEIGHTS.tall, "w-full")}
+        >
+          <AreaChart data={data}>
+            <CartesianGrid {...CHART_GRID.default} />
+            <XAxis
+              dataKey="month"
+              tickLine={false}
+              axisLine={false}
+              tickMargin={8}
+              tickFormatter={(value) => {
+                const [year, month] = value.split("-");
+                return `${month}/${year.slice(2)}`;
+              }}
+              interval="preserveStartEnd"
+              minTickGap={40}
+            />
+            <YAxis
+              tickLine={false}
+              axisLine={false}
+              tickFormatter={(value) => `${value.toFixed(0)}%`}
+              width={50}
+            />
+            <ChartTooltip
+              cursor={CHART_CURSOR.highlight}
+              content={
+                <ChartTooltipContent
+                  formatter={(value) => `${(value as number).toFixed(1)}%`}
+                />
+              }
+            />
+            <Area
+              type="monotone"
+              dataKey="evShare"
+              fill="var(--chart-1)"
+              stroke="var(--chart-1)"
+              fillOpacity={0.3}
+            />
+          </AreaChart>
+        </ChartContainer>
+      </CardBody>
+      <CardFooter>
+        <Typography.TextSm className="text-default-500">
+          Includes BEV, PHEV, and conventional hybrid vehicles as a share of
+          total new registrations each month.
+        </Typography.TextSm>
+      </CardFooter>
+    </Card>
+  );
+}

--- a/apps/web/src/app/(main)/(explore)/cars/electric-vehicles/components/top-makes-chart.tsx
+++ b/apps/web/src/app/(main)/(explore)/cars/electric-vehicles/components/top-makes-chart.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import { Card, CardBody, CardFooter, CardHeader } from "@heroui/card";
+import { cn } from "@heroui/theme";
+import {
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+} from "@sgcarstrends/ui/components/chart";
+import Typography from "@web/components/typography";
+import {
+  CARD_PADDING,
+  CHART_CURSOR,
+  CHART_GRID,
+  CHART_HEIGHTS,
+  RADIUS,
+} from "@web/config/design-system";
+import type { EvTopMake } from "@web/queries/cars/electric-vehicles";
+import { Bar, BarChart, CartesianGrid, Cell, XAxis, YAxis } from "recharts";
+
+interface TopMakesChartProps {
+  data: EvTopMake[];
+  month: string;
+}
+
+const chartConfig = {
+  count: { label: "Registrations", color: "var(--chart-1)" },
+};
+
+export function TopMakesChart({ data, month }: TopMakesChartProps) {
+  const numberFormatter = new Intl.NumberFormat("en-SG");
+
+  return (
+    <Card className={cn(RADIUS.card, CARD_PADDING.standard)}>
+      <CardHeader className="flex flex-col items-start gap-2">
+        <Typography.H4>Top EV Makes</Typography.H4>
+        <Typography.TextSm className="text-default-500">
+          Top 10 electrified vehicle makes for {month}
+        </Typography.TextSm>
+      </CardHeader>
+      <CardBody>
+        <ChartContainer
+          config={chartConfig}
+          className={cn(CHART_HEIGHTS.tall, "w-full")}
+        >
+          <BarChart data={data} layout="vertical">
+            <CartesianGrid {...CHART_GRID.default} horizontal={false} />
+            <XAxis
+              type="number"
+              tickLine={false}
+              axisLine={false}
+              tickFormatter={(value) => numberFormatter.format(value)}
+            />
+            <YAxis
+              type="category"
+              dataKey="make"
+              tickLine={false}
+              axisLine={false}
+              width={100}
+            />
+            <ChartTooltip
+              cursor={CHART_CURSOR.highlight}
+              content={
+                <ChartTooltipContent
+                  formatter={(value) => numberFormatter.format(value as number)}
+                />
+              }
+            />
+            <Bar dataKey="count" radius={[0, 4, 4, 0]}>
+              {data.map((entry, index) => (
+                <Cell
+                  key={entry.make}
+                  fill={`var(--chart-${Math.min(index + 1, 6)})`}
+                />
+              ))}
+            </Bar>
+          </BarChart>
+        </ChartContainer>
+      </CardBody>
+      <CardFooter>
+        <Typography.TextSm className="text-default-500">
+          Includes BEV, PHEV, and hybrid registrations combined.
+        </Typography.TextSm>
+      </CardFooter>
+    </Card>
+  );
+}

--- a/apps/web/src/app/(main)/(explore)/cars/electric-vehicles/constants.ts
+++ b/apps/web/src/app/(main)/(explore)/cars/electric-vehicles/constants.ts
@@ -1,0 +1,17 @@
+export const EV_FUEL_TYPES = {
+  BEV: ["Electric"],
+  PHEV: ["Petrol-Electric (Plug-In)", "Diesel-Electric (Plug-In)"],
+  Hybrid: ["Petrol-Electric", "Diesel-Electric"],
+} as const;
+
+export const EV_COLORS = {
+  BEV: "var(--chart-1)",
+  PHEV: "var(--chart-3)",
+  Hybrid: "var(--chart-5)",
+} as const;
+
+export const ALL_EV_FUEL_TYPES = [
+  ...EV_FUEL_TYPES.BEV,
+  ...EV_FUEL_TYPES.PHEV,
+  ...EV_FUEL_TYPES.Hybrid,
+];

--- a/apps/web/src/app/(main)/(explore)/cars/electric-vehicles/page.tsx
+++ b/apps/web/src/app/(main)/(explore)/cars/electric-vehicles/page.tsx
@@ -1,5 +1,6 @@
 import { AdoptionTrendChart } from "@web/app/(main)/(explore)/cars/electric-vehicles/components/adoption-trend-chart";
 import { EvMetrics } from "@web/app/(main)/(explore)/cars/electric-vehicles/components/ev-metrics";
+import { MakeTable } from "@web/app/(main)/(explore)/cars/electric-vehicles/components/make-table";
 import { MarketShareChart } from "@web/app/(main)/(explore)/cars/electric-vehicles/components/market-share-chart";
 import { TopMakesChart } from "@web/app/(main)/(explore)/cars/electric-vehicles/components/top-makes-chart";
 import { AnimatedSection } from "@web/app/(main)/(explore)/components/animated-section";
@@ -12,6 +13,7 @@ import { StructuredData } from "@web/components/structured-data";
 import { SITE_TITLE, SITE_URL } from "@web/config";
 import {
   getEvLatestSummary,
+  getEvMakeDetails,
   getEvMarketShare,
   getEvMonthlyTrend,
   getEvTopMakes,
@@ -50,12 +52,14 @@ const structuredData: WithContext<WebPage> = {
 };
 
 export default async function ElectricVehiclesPage() {
-  const [summary, monthlyTrend, marketShare, topMakes] = await Promise.all([
-    getEvLatestSummary(),
-    getEvMonthlyTrend(),
-    getEvMarketShare(),
-    getEvTopMakes(),
-  ]);
+  const [summary, monthlyTrend, marketShare, topMakes, makeDetails] =
+    await Promise.all([
+      getEvLatestSummary(),
+      getEvMonthlyTrend(),
+      getEvMarketShare(),
+      getEvTopMakes(),
+      getEvMakeDetails(),
+    ]);
 
   if (!summary) {
     return (
@@ -103,6 +107,10 @@ export default async function ElectricVehiclesPage() {
 
         <AnimatedSection order={5}>
           <TopMakesChart data={topMakes} month={summary.month} />
+        </AnimatedSection>
+
+        <AnimatedSection order={6}>
+          <MakeTable data={makeDetails} month={summary.month} />
         </AnimatedSection>
       </section>
     </>

--- a/apps/web/src/app/(main)/(explore)/cars/electric-vehicles/page.tsx
+++ b/apps/web/src/app/(main)/(explore)/cars/electric-vehicles/page.tsx
@@ -1,0 +1,110 @@
+import { AdoptionTrendChart } from "@web/app/(main)/(explore)/cars/electric-vehicles/components/adoption-trend-chart";
+import { EvMetrics } from "@web/app/(main)/(explore)/cars/electric-vehicles/components/ev-metrics";
+import { MarketShareChart } from "@web/app/(main)/(explore)/cars/electric-vehicles/components/market-share-chart";
+import { TopMakesChart } from "@web/app/(main)/(explore)/cars/electric-vehicles/components/top-makes-chart";
+import { AnimatedSection } from "@web/app/(main)/(explore)/components/animated-section";
+import { DashboardPageHeader } from "@web/components/dashboard-page-header";
+import { DashboardPageTitle } from "@web/components/dashboard-page-title";
+import { EmptyState } from "@web/components/shared/empty-state";
+import { PageContext } from "@web/components/shared/page-context";
+import { PAGE_CONTEXTS } from "@web/components/shared/page-contexts";
+import { StructuredData } from "@web/components/structured-data";
+import { SITE_TITLE, SITE_URL } from "@web/config";
+import {
+  getEvLatestSummary,
+  getEvMarketShare,
+  getEvMonthlyTrend,
+  getEvTopMakes,
+} from "@web/queries/cars";
+import { Zap } from "lucide-react";
+import type { Metadata } from "next";
+import type { WebPage, WithContext } from "schema-dts";
+
+export const metadata: Metadata = {
+  title: "Electric Vehicles | Singapore EV Trends",
+  description:
+    "Track Singapore's electric vehicle adoption with BEV, PHEV, and hybrid registration trends, market share analysis, and top EV makes.",
+  openGraph: {
+    title: "Electric Vehicles - Singapore EV Trends",
+    description:
+      "Explore BEV, PHEV, and hybrid adoption trends, market share, and brand rankings in Singapore.",
+    type: "website",
+  },
+  alternates: {
+    canonical: "/cars/electric-vehicles",
+  },
+};
+
+const structuredData: WithContext<WebPage> = {
+  "@context": "https://schema.org",
+  "@type": "WebPage",
+  name: "Electric Vehicles",
+  description:
+    "Singapore electric vehicle adoption trends including BEV, PHEV, and hybrid registrations, market share analysis, and top EV makes",
+  url: `${SITE_URL}/cars/electric-vehicles`,
+  publisher: {
+    "@type": "Organization",
+    name: SITE_TITLE,
+    url: SITE_URL,
+  },
+};
+
+export default async function ElectricVehiclesPage() {
+  const [summary, monthlyTrend, marketShare, topMakes] = await Promise.all([
+    getEvLatestSummary(),
+    getEvMonthlyTrend(),
+    getEvMarketShare(),
+    getEvTopMakes(),
+  ]);
+
+  if (!summary) {
+    return (
+      <EmptyState
+        icon={
+          <div className="flex size-16 items-center justify-center rounded-2xl bg-default-100">
+            <Zap className="size-8 text-default-400" />
+          </div>
+        }
+        title="No Data Available Yet"
+        description="Electric vehicle registration data is not available at the moment. Please check back later."
+        showDefaultActions={false}
+      />
+    );
+  }
+
+  return (
+    <>
+      <StructuredData data={structuredData} />
+      <section className="flex flex-col gap-10">
+        <DashboardPageHeader
+          title={
+            <DashboardPageTitle
+              title="Electric Vehicles"
+              subtitle="BEV, PHEV, and hybrid adoption trends and market share in Singapore."
+            />
+          }
+        />
+
+        <AnimatedSection order={1}>
+          <PageContext {...PAGE_CONTEXTS.electricVehicles} />
+        </AnimatedSection>
+
+        <AnimatedSection order={2}>
+          <EvMetrics summary={summary} />
+        </AnimatedSection>
+
+        <AnimatedSection order={3}>
+          <AdoptionTrendChart data={monthlyTrend} />
+        </AnimatedSection>
+
+        <AnimatedSection order={4}>
+          <MarketShareChart data={marketShare} />
+        </AnimatedSection>
+
+        <AnimatedSection order={5}>
+          <TopMakesChart data={topMakes} month={summary.month} />
+        </AnimatedSection>
+      </section>
+    </>
+  );
+}

--- a/apps/web/src/components/shared/page-contexts.ts
+++ b/apps/web/src/components/shared/page-contexts.ts
@@ -32,4 +32,10 @@ It provides insights into fleet turnover and the impact of the 10-year COE lifec
 
 **Budget 2026 Changes (effective Feb 2026):** Rebate percentages cut by 45 percentage points across all brackets, and the cap halved from $60,000 to $30,000.`,
   },
+  electricVehicles: {
+    title: "Singapore's EV Story",
+    content: `Singapore is accelerating its transition to **electric vehicles (EVs)** as part of the **Singapore Green Plan 2030**. The goal is to phase out internal combustion engine vehicles by 2040 and have all vehicles run on cleaner energy.
+
+This page tracks three categories of electrified vehicles: **BEV** (Battery Electric), **PHEV** (Plug-In Hybrid), and **Hybrid** (conventional hybrid). Together they show how Singapore's roads are going green.`,
+  },
 } as const;

--- a/apps/web/src/config/navigation.ts
+++ b/apps/web/src/config/navigation.ts
@@ -22,11 +22,8 @@ import {
   LayoutDashboard,
   type LucideIcon,
   TrendingUp,
-  Zap,
 } from "lucide-react";
 import type { Route } from "next";
-
-export const POLAR_DONATION_URL = "https://polar.sh/sgcarstrends";
 
 export interface NavigationItem {
   title: string;
@@ -137,14 +134,6 @@ export const navLinks: NavLinks = {
       icon: Calendar,
       description: "Yearly vehicle population and registration trends",
       iconColor: "text-amber-500",
-    },
-    {
-      title: "Electric Vehicles",
-      url: "/cars/electric-vehicles",
-      icon: Zap,
-      description: "BEV, PHEV and hybrid adoption trends and market share",
-      badge: "new",
-      iconColor: "text-emerald-500",
     },
     {
       title: "PARF Calculator",

--- a/apps/web/src/config/navigation.ts
+++ b/apps/web/src/config/navigation.ts
@@ -22,6 +22,7 @@ import {
   LayoutDashboard,
   type LucideIcon,
   TrendingUp,
+  Zap,
 } from "lucide-react";
 import type { Route } from "next";
 
@@ -134,6 +135,14 @@ export const navLinks: NavLinks = {
       icon: Calendar,
       description: "Yearly vehicle population and registration trends",
       iconColor: "text-amber-500",
+    },
+    {
+      title: "Electric Vehicles",
+      url: "/cars/electric-vehicles",
+      icon: Zap,
+      description: "BEV, PHEV and hybrid adoption trends and market share",
+      badge: "new",
+      iconColor: "text-emerald-500",
     },
     {
       title: "PARF Calculator",

--- a/apps/web/src/config/navigation.ts
+++ b/apps/web/src/config/navigation.ts
@@ -26,6 +26,8 @@ import {
 } from "lucide-react";
 import type { Route } from "next";
 
+export const POLAR_DONATION_URL = "https://polar.sh/sgcarstrends";
+
 export interface NavigationItem {
   title: string;
   url: string;

--- a/apps/web/src/queries/cars/electric-vehicles.ts
+++ b/apps/web/src/queries/cars/electric-vehicles.ts
@@ -1,0 +1,220 @@
+import { cars, db, desc, eq, inArray, sql } from "@sgcarstrends/database";
+import { cacheLife, cacheTag } from "next/cache";
+
+const BEV_FUEL_TYPES = ["Electric"];
+const PHEV_FUEL_TYPES = [
+  "Petrol-Electric (Plug-In)",
+  "Diesel-Electric (Plug-In)",
+];
+const HYBRID_FUEL_TYPES = ["Petrol-Electric", "Diesel-Electric"];
+const ALL_EV_FUEL_TYPES = [
+  ...BEV_FUEL_TYPES,
+  ...PHEV_FUEL_TYPES,
+  ...HYBRID_FUEL_TYPES,
+];
+
+export interface EvMonthlyTrend {
+  month: string;
+  BEV: number;
+  PHEV: number;
+  Hybrid: number;
+}
+
+export interface EvMarketShare {
+  month: string;
+  evCount: number;
+  totalCount: number;
+  evShare: number;
+}
+
+export interface EvTopMake {
+  make: string;
+  count: number;
+}
+
+export interface EvLatestSummary {
+  month: string;
+  totalEv: number;
+  evSharePercent: number;
+  bevCount: number;
+  topMake: string;
+}
+
+export async function getEvMonthlyTrend(): Promise<EvMonthlyTrend[]> {
+  "use cache";
+  cacheLife("max");
+  cacheTag("cars:fuel:electric", "cars:fuel:hybrid");
+
+  const results = await db
+    .select({
+      month: cars.month,
+      fuelType: cars.fuelType,
+      count: sql<number>`sum(${cars.number})`.mapWith(Number),
+    })
+    .from(cars)
+    .where(inArray(cars.fuelType, ALL_EV_FUEL_TYPES))
+    .groupBy(cars.month, cars.fuelType)
+    .orderBy(cars.month);
+
+  const monthMap = new Map<string, EvMonthlyTrend>();
+
+  for (const row of results) {
+    if (!monthMap.has(row.month)) {
+      monthMap.set(row.month, { month: row.month, BEV: 0, PHEV: 0, Hybrid: 0 });
+    }
+    const entry = monthMap.get(row.month)!;
+
+    if (BEV_FUEL_TYPES.includes(row.fuelType)) {
+      entry.BEV += row.count;
+    } else if (PHEV_FUEL_TYPES.includes(row.fuelType)) {
+      entry.PHEV += row.count;
+    } else if (HYBRID_FUEL_TYPES.includes(row.fuelType)) {
+      entry.Hybrid += row.count;
+    }
+  }
+
+  return Array.from(monthMap.values());
+}
+
+export async function getEvMarketShare(): Promise<EvMarketShare[]> {
+  "use cache";
+  cacheLife("max");
+  cacheTag("cars:fuel:electric", "cars:fuel:hybrid");
+
+  const evByMonthQuery = db
+    .select({
+      month: cars.month,
+      evCount: sql<number>`sum(${cars.number})`.mapWith(Number),
+    })
+    .from(cars)
+    .where(inArray(cars.fuelType, ALL_EV_FUEL_TYPES))
+    .groupBy(cars.month);
+
+  const totalByMonthQuery = db
+    .select({
+      month: cars.month,
+      totalCount: sql<number>`sum(${cars.number})`.mapWith(Number),
+    })
+    .from(cars)
+    .groupBy(cars.month);
+
+  const [evByMonth, totalByMonth] = await db.batch([
+    evByMonthQuery,
+    totalByMonthQuery,
+  ]);
+
+  const totalMap = new Map(totalByMonth.map((r) => [r.month, r.totalCount]));
+
+  return evByMonth
+    .map((row) => {
+      const total = totalMap.get(row.month) ?? 0;
+      return {
+        month: row.month,
+        evCount: row.evCount,
+        totalCount: total,
+        evShare: total > 0 ? (row.evCount / total) * 100 : 0,
+      };
+    })
+    .sort((a, b) => a.month.localeCompare(b.month));
+}
+
+export async function getEvTopMakes(limit = 10): Promise<EvTopMake[]> {
+  "use cache";
+  cacheLife("max");
+  cacheTag("cars:fuel:electric", "cars:fuel:hybrid");
+
+  const latestMonthResult = await db
+    .select({ month: cars.month })
+    .from(cars)
+    .where(inArray(cars.fuelType, ALL_EV_FUEL_TYPES))
+    .orderBy(desc(cars.month))
+    .limit(1);
+
+  const latestMonth = latestMonthResult[0]?.month;
+  if (!latestMonth) return [];
+
+  return db
+    .select({
+      make: cars.make,
+      count: sql<number>`sum(${cars.number})`.mapWith(Number),
+    })
+    .from(cars)
+    .where(
+      sql`${cars.month} = ${latestMonth} AND ${cars.fuelType} IN ${ALL_EV_FUEL_TYPES}`,
+    )
+    .groupBy(cars.make)
+    .orderBy(desc(sql<number>`sum(${cars.number})`))
+    .limit(limit);
+}
+
+export async function getEvLatestSummary(): Promise<EvLatestSummary | null> {
+  "use cache";
+  cacheLife("max");
+  cacheTag("cars:fuel:electric", "cars:fuel:hybrid");
+
+  const latestMonthResult = await db
+    .select({ month: cars.month })
+    .from(cars)
+    .where(inArray(cars.fuelType, ALL_EV_FUEL_TYPES))
+    .orderBy(desc(cars.month))
+    .limit(1);
+
+  const latestMonth = latestMonthResult[0]?.month;
+  if (!latestMonth) return null;
+
+  const evTotalQuery = db
+    .select({
+      count: sql<number>`sum(${cars.number})`.mapWith(Number),
+    })
+    .from(cars)
+    .where(
+      sql`${cars.month} = ${latestMonth} AND ${cars.fuelType} IN ${ALL_EV_FUEL_TYPES}`,
+    );
+
+  const bevTotalQuery = db
+    .select({
+      count: sql<number>`sum(${cars.number})`.mapWith(Number),
+    })
+    .from(cars)
+    .where(
+      sql`${cars.month} = ${latestMonth} AND ${cars.fuelType} IN ${BEV_FUEL_TYPES}`,
+    );
+
+  const allTotalQuery = db
+    .select({
+      count: sql<number>`sum(${cars.number})`.mapWith(Number),
+    })
+    .from(cars)
+    .where(eq(cars.month, latestMonth));
+
+  const topMakeQuery = db
+    .select({
+      make: cars.make,
+      count: sql<number>`sum(${cars.number})`.mapWith(Number),
+    })
+    .from(cars)
+    .where(
+      sql`${cars.month} = ${latestMonth} AND ${cars.fuelType} IN ${ALL_EV_FUEL_TYPES}`,
+    )
+    .groupBy(cars.make)
+    .orderBy(desc(sql<number>`sum(${cars.number})`))
+    .limit(1);
+
+  const [evTotal, bevTotal, allTotal, topMake] = await db.batch([
+    evTotalQuery,
+    bevTotalQuery,
+    allTotalQuery,
+    topMakeQuery,
+  ]);
+
+  const totalEv = evTotal[0]?.count ?? 0;
+  const total = allTotal[0]?.count ?? 0;
+
+  return {
+    month: latestMonth,
+    totalEv,
+    evSharePercent: total > 0 ? (totalEv / total) * 100 : 0,
+    bevCount: bevTotal[0]?.count ?? 0,
+    topMake: topMake[0]?.make ?? "N/A",
+  };
+}

--- a/apps/web/src/queries/cars/index.ts
+++ b/apps/web/src/queries/cars/index.ts
@@ -1,6 +1,7 @@
 export * from "./categories";
 export * from "./category-summary";
 export * from "./compare";
+export * from "./electric-vehicles";
 export * from "./filter-options";
 export * from "./latest-month";
 export * from "./makes";

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -67,6 +67,9 @@ export default defineConfig({
         "src/components/charts/base/**",
         "src/components/shared/skeleton.tsx",
 
+        // EV queries (DB aggregation, no testable logic without DB)
+        "src/queries/cars/electric-vehicles.ts",
+
         // Simple DB/API wrappers (no business logic)
         "src/queries/cars/latest-month.ts",
         "src/utils/social/linkedin.ts",


### PR DESCRIPTION
- Add `/cars/electric-vehicles` page with BEV, PHEV, and hybrid adoption trends
- 5 cached query functions: monthly trend, market share, top makes, make details, latest summary
- Stacked area chart for adoption trend, area chart for market share %, horizontal bar chart for top 10 makes
- Sortable paginated table showing EV registrations by make with BEV/PHEV/Hybrid breakdown
- Metric cards showing total EV registrations, market share %, BEV count, and top make
- EV page context explaining Singapore Green Plan 2030 and electrified vehicle categories
- Navigation entry with Zap icon and "new" badge
- Add Polar.sh donation link to footer wrapped with `UnreleasedFeature`

Closes #726