### PR TITLE
Download COE ZIP once for both coe and pqp tables

### DIFF
--- a/apps/web/src/lib/updater/services/download-file.ts
+++ b/apps/web/src/lib/updater/services/download-file.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import { AWS_LAMBDA_TEMP_DIR } from "@web/config/workflow";
 import AdmZip from "adm-zip";
 
@@ -40,3 +41,38 @@ export const downloadFile = async (url: string, csvFile?: string) => {
     throw error;
   }
 };
+
+export async function fetchAndExtractZip(
+  url: string,
+): Promise<Map<string, string>> {
+  const response = await fetch(url);
+
+  if (!response.ok) {
+    const errorBody = await response.text();
+    console.error("Download failed:", {
+      status: response.status,
+      statusText: response.statusText,
+      url,
+      errorBody: errorBody.substring(0, 500),
+      timestamp: new Date().toISOString(),
+    });
+    throw new Error(`HTTP error! status: ${response.status}`);
+  }
+
+  const arrayBuffer = await response.arrayBuffer();
+  const zip = new AdmZip(Buffer.from(arrayBuffer));
+  const extracted = new Map<string, string>();
+
+  for (const entry of zip.getEntries()) {
+    if (!entry.isDirectory) {
+      console.log("Found file in ZIP:", entry.entryName);
+      zip.extractEntryTo(entry, AWS_LAMBDA_TEMP_DIR, true, true);
+      extracted.set(
+        entry.entryName,
+        path.join(AWS_LAMBDA_TEMP_DIR, entry.entryName),
+      );
+    }
+  }
+
+  return extracted;
+}

--- a/apps/web/src/lib/updater/services/index.ts
+++ b/apps/web/src/lib/updater/services/index.ts
@@ -1,5 +1,5 @@
 export { Checksum } from "@web/utils/checksum";
 export { calculateChecksum } from "./calculate-checksum";
-export { downloadFile } from "./download-file";
+export { downloadFile, fetchAndExtractZip } from "./download-file";
 export type { CSVTransformOptions } from "./process-csv";
 export { processCsv } from "./process-csv";

--- a/apps/web/src/lib/updater/updater.test.ts
+++ b/apps/web/src/lib/updater/updater.test.ts
@@ -261,6 +261,24 @@ describe("update", () => {
     );
   });
 
+  it("should skip download when filePath is provided", async () => {
+    vi.mocked(mockChecksum.getCachedChecksum).mockResolvedValue(null);
+
+    const configWithFilePath = {
+      ...updaterConfig,
+      filePath: "/tmp/pre-extracted.csv",
+    };
+
+    await update(configWithFilePath, updaterOptions);
+
+    expect(downloadFile).not.toHaveBeenCalled();
+    expect(calculateChecksum).toHaveBeenCalledWith("/tmp/pre-extracted.csv");
+    expect(mockChecksum.cacheChecksum).toHaveBeenCalledWith(
+      "pre-extracted.csv",
+      "abc123",
+    );
+  });
+
   it("should insert all records when partition is new (Phase 1)", async () => {
     vi.mocked(mockChecksum.getCachedChecksum).mockResolvedValue(null);
 

--- a/apps/web/src/workflows/coe/steps/process-data.test.ts
+++ b/apps/web/src/workflows/coe/steps/process-data.test.ts
@@ -11,7 +11,12 @@ vi.mock("@web/lib/updater", () => ({
   update: vi.fn(),
 }));
 
+vi.mock("@web/lib/updater/services/download-file", () => ({
+  fetchAndExtractZip: vi.fn(),
+}));
+
 import { type UpdaterResult, update } from "@web/lib/updater";
+import { fetchAndExtractZip } from "@web/lib/updater/services/download-file";
 import { updateCoe } from "./process-data";
 
 const mockResult = (overrides?: Partial<UpdaterResult>): UpdaterResult => ({
@@ -22,12 +27,18 @@ const mockResult = (overrides?: Partial<UpdaterResult>): UpdaterResult => ({
   ...overrides,
 });
 
+const mockExtractedFiles = new Map([
+  ["M11-coe_results.csv", "/tmp/M11-coe_results.csv"],
+  ["M11-coe_results_pqp.csv", "/tmp/M11-coe_results_pqp.csv"],
+]);
+
 describe("updateCoe", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(fetchAndExtractZip).mockResolvedValue(mockExtractedFiles);
   });
 
-  it("should call update with correct COE and PQP configurations", async () => {
+  it("should download ZIP once and process both tables", async () => {
     vi.mocked(update)
       .mockResolvedValueOnce(
         mockResult({ recordsProcessed: 10, message: "10 records inserted" }),
@@ -42,19 +53,30 @@ describe("updateCoe", () => {
 
     await updateCoe();
 
-    expect(update).toHaveBeenCalledTimes(2);
+    expect(fetchAndExtractZip).toHaveBeenCalledTimes(1);
+    expect(fetchAndExtractZip).toHaveBeenCalledWith(
+      "https://example.com/datamall/COE Bidding Results.zip",
+    );
 
-    // First call - COE
+    expect(update).toHaveBeenCalledTimes(2);
+  });
+
+  it("should pass filePath to update calls instead of triggering downloads", async () => {
+    vi.mocked(update)
+      .mockResolvedValueOnce(mockResult())
+      .mockResolvedValueOnce(mockResult({ table: "pqp" }));
+
+    await updateCoe();
+
+    // COE call uses filePath
     expect(vi.mocked(update).mock.calls[0][0]).toMatchObject({
-      url: "https://example.com/datamall/COE Bidding Results.zip",
-      csvFile: "M11-coe_results.csv",
+      filePath: "/tmp/M11-coe_results.csv",
       keyFields: ["month", "biddingNo"],
     });
 
-    // Second call - PQP
+    // PQP call uses filePath
     expect(vi.mocked(update).mock.calls[1][0]).toMatchObject({
-      url: "https://example.com/datamall/COE Bidding Results.zip",
-      csvFile: "M11-coe_results_pqp.csv",
+      filePath: "/tmp/M11-coe_results_pqp.csv",
       keyFields: ["month", "vehicleClass", "pqp"],
     });
   });
@@ -77,6 +99,16 @@ describe("updateCoe", () => {
     const result = await updateCoe();
 
     expect(result).toEqual(coeResult);
+  });
+
+  it("should throw when expected CSV files are missing from ZIP", async () => {
+    vi.mocked(fetchAndExtractZip).mockResolvedValue(
+      new Map([["unexpected.csv", "/tmp/unexpected.csv"]]),
+    );
+
+    await expect(updateCoe()).rejects.toThrow(
+      "Expected CSV files not found in ZIP",
+    );
   });
 
   it("should configure COE column mappings correctly", async () => {


### PR DESCRIPTION
- Add `fetchAndExtractZip()` to download and extract all files from a ZIP in one pass, returning a `Map<filename, path>`
- Add `filePath` option to `UpdaterConfig` — when set, `update()` skips the download step and uses the pre-extracted path directly
- Refactor `updateCoe()` to call `fetchAndExtractZip()` once, then pass each CSV path to `update()` via `filePath`
- Previously the same ZIP was fetched twice per run (once for `coe`, once for `pqp`)

Closes #732