### PR TITLE
Rebrand frontend to MotorMetrics (Phase 2)

### DIFF
--- a/apps/web/src/app/(main)/(explore)/cars/deregistrations/page.tsx
+++ b/apps/web/src/app/(main)/(explore)/cars/deregistrations/page.tsx
@@ -132,9 +132,9 @@ export async function generateMetadata({
       creator: SOCIAL_HANDLE,
     },
     alternates: { canonical },
-    authors: [{ name: "SG Cars Trends", url: SITE_URL }],
-    creator: "SG Cars Trends",
-    publisher: "SG Cars Trends",
+    authors: [{ name: SITE_TITLE, url: SITE_URL }],
+    creator: SITE_TITLE,
+    publisher: SITE_TITLE,
   });
 
   try {

--- a/apps/web/src/app/(main)/(explore)/cars/registrations/page.tsx
+++ b/apps/web/src/app/(main)/(explore)/cars/registrations/page.tsx
@@ -63,9 +63,9 @@ export async function generateMetadata({
     alternates: {
       canonical: `/cars/registrations?month=${month}`,
     },
-    authors: [{ name: "SG Cars Trends", url: SITE_URL }],
-    creator: "SG Cars Trends",
-    publisher: "SG Cars Trends",
+    authors: [{ name: SITE_TITLE, url: SITE_URL }],
+    creator: SITE_TITLE,
+    publisher: SITE_TITLE,
   };
 }
 

--- a/apps/web/src/app/(main)/(explore)/coe/premiums/page.tsx
+++ b/apps/web/src/app/(main)/(explore)/coe/premiums/page.tsx
@@ -55,9 +55,9 @@ export async function generateMetadata(): Promise<Metadata> {
     alternates: {
       canonical: "/coe/premiums",
     },
-    authors: [{ name: "SG Cars Trends", url: SITE_URL }],
-    creator: "SG Cars Trends",
-    publisher: "SG Cars Trends",
+    authors: [{ name: SITE_TITLE, url: SITE_URL }],
+    creator: SITE_TITLE,
+    publisher: SITE_TITLE,
   };
 }
 

--- a/apps/web/src/app/(main)/(explore)/coe/results/page.tsx
+++ b/apps/web/src/app/(main)/(explore)/coe/results/page.tsx
@@ -69,9 +69,9 @@ export async function generateMetadata(): Promise<Metadata> {
     alternates: {
       canonical: "/coe/results",
     },
-    authors: [{ name: "SG Cars Trends", url: SITE_URL }],
-    creator: "SG Cars Trends",
-    publisher: "SG Cars Trends",
+    authors: [{ name: SITE_TITLE, url: SITE_URL }],
+    creator: SITE_TITLE,
+    publisher: SITE_TITLE,
   };
 }
 

--- a/apps/web/src/app/(main)/(explore)/opengraph-image.tsx
+++ b/apps/web/src/app/(main)/(explore)/opengraph-image.tsx
@@ -4,7 +4,7 @@ import { Section } from "@web/lib/og/templates/section";
 import { ImageResponse } from "next/og";
 
 export const alt =
-  "SG Cars Trends - Singapore Car Registration & COE Statistics";
+  "MotorMetrics - Singapore Car Registration & COE Statistics";
 export const size = OG_SIZE;
 export const contentType = "image/png";
 

--- a/apps/web/src/app/(main)/(site)/about/components/creator-section.tsx
+++ b/apps/web/src/app/(main)/(site)/about/components/creator-section.tsx
@@ -2,6 +2,7 @@
 
 import { Link } from "@heroui/link";
 import Typography from "@web/components/typography";
+import { SITE_TITLE } from "@web/config";
 import {
   staggerContainerVariants,
   staggerItemVariants,
@@ -45,7 +46,7 @@ export function CreatorSection() {
                 Singapore
               </Typography.H2>
               <Typography.TextLg className="text-default-600">
-                SG Cars Trends is an independent project created by{" "}
+                {SITE_TITLE} is an independent project created by{" "}
                 <Link
                   href="https://ruchern.dev"
                   isExternal

--- a/apps/web/src/app/(main)/(site)/about/components/mission-section.tsx
+++ b/apps/web/src/app/(main)/(site)/about/components/mission-section.tsx
@@ -2,6 +2,7 @@
 
 import { Card, CardBody } from "@heroui/card";
 import Typography from "@web/components/typography";
+import { SITE_TITLE } from "@web/config";
 import { fadeInUpVariants } from "@web/config/animations";
 import { motion } from "framer-motion";
 
@@ -45,7 +46,7 @@ export function MissionSection() {
                 decisions feels nearly impossible.
               </Typography.TextLg>
               <Typography.TextLg className="text-default-600">
-                We built SG Cars Trends to change that. By aggregating official
+                We built {SITE_TITLE} to change that. By aggregating official
                 data from the Land Transport Authority and presenting it through
                 intuitive visualisations, we hope to make this data easier to
                 find and explore, rather than scattered across government

--- a/apps/web/src/app/(main)/(site)/about/opengraph-image.tsx
+++ b/apps/web/src/app/(main)/(site)/about/opengraph-image.tsx
@@ -3,7 +3,7 @@ import { getOGFonts } from "@web/lib/og/fonts";
 import { Section } from "@web/lib/og/templates/section";
 import { ImageResponse } from "next/og";
 
-export const alt = "About SG Cars Trends";
+export const alt = "About MotorMetrics";
 export const size = OG_SIZE;
 export const contentType = "image/png";
 
@@ -14,7 +14,7 @@ export default function Image() {
     <Section
       eyebrow="Behind the Data"
       headlineTop="The Story Behind"
-      headlineBottom="SG Cars Trends"
+      headlineBottom="MotorMetrics"
       description="A platform for exploring Singapore car registration statistics, COE bidding results, and market data. Built to make car market information easier to find and understand."
     />,
     {

--- a/apps/web/src/app/(main)/(site)/about/page.tsx
+++ b/apps/web/src/app/(main)/(site)/about/page.tsx
@@ -11,9 +11,8 @@ import { MissionSection } from "./components/mission-section";
 import { StatsSection } from "./components/stats-section";
 import { TimelineSection } from "./components/timeline-section";
 
-const title = "About SG Cars Trends";
-const description =
-  "Learn about SG Cars Trends, a platform for exploring Singapore car registration statistics, COE bidding results, and market data. Built to make car market information easier to find and understand.";
+const title = `About ${SITE_TITLE}`;
+const description = `Learn about ${SITE_TITLE}, a platform for exploring Singapore car registration statistics, COE bidding results, and market data. Built to make car market information easier to find and understand.`;
 
 export const metadata: Metadata = {
   title,

--- a/apps/web/src/app/(main)/(site)/advertise/components/hero-section.tsx
+++ b/apps/web/src/app/(main)/(site)/advertise/components/hero-section.tsx
@@ -3,6 +3,7 @@
 import { Button } from "@heroui/button";
 import { Chip } from "@heroui/chip";
 import { Link } from "@heroui/link";
+import { SITE_TITLE } from "@web/config";
 import { motion } from "framer-motion";
 import { ArrowRight, BarChart3 } from "lucide-react";
 
@@ -65,7 +66,7 @@ export function HeroSection() {
             animate={{ opacity: 1, y: 0, scale: 1 }}
             transition={entranceTransition(0.3)}
           >
-            SG Cars Trends reaches an engaged, technical audience of car buyers,
+            {SITE_TITLE} reaches an engaged, technical audience of car buyers,
             owners, and enthusiasts actively researching Singapore&apos;s
             automotive market.
           </motion.p>

--- a/apps/web/src/app/(main)/(site)/advertise/opengraph-image.tsx
+++ b/apps/web/src/app/(main)/(site)/advertise/opengraph-image.tsx
@@ -3,7 +3,7 @@ import { getOGFonts } from "@web/lib/og/fonts";
 import { Section } from "@web/lib/og/templates/section";
 import { ImageResponse } from "next/og";
 
-export const alt = "Advertise on SG Cars Trends";
+export const alt = "Advertise on MotorMetrics";
 export const size = OG_SIZE;
 export const contentType = "image/png";
 

--- a/apps/web/src/app/(main)/(site)/advertise/page.tsx
+++ b/apps/web/src/app/(main)/(site)/advertise/page.tsx
@@ -13,8 +13,7 @@ import { StatsSection } from "./components/stats-section";
 import { TrafficChartSection } from "./components/traffic-chart-section";
 
 const title = "Advertise";
-const description =
-  "Reach Singapore's most engaged car enthusiasts. See our traffic stats, ad placements, and pricing to promote your product on SG Cars Trends.";
+const description = `Reach Singapore's most engaged car enthusiasts. See our traffic stats, ad placements, and pricing to promote your product on ${SITE_TITLE}.`;
 
 export const metadata: Metadata = {
   title,

--- a/apps/web/src/app/(main)/(site)/blog/[slug]/page.tsx
+++ b/apps/web/src/app/(main)/(site)/blog/[slug]/page.tsx
@@ -13,7 +13,7 @@ import { RelatedPosts } from "@web/app/(main)/(site)/blog/components/related-pos
 import { ShareButtons } from "@web/app/(main)/(site)/blog/components/share-buttons";
 import { TableOfContents } from "@web/app/(main)/(site)/blog/components/table-of-contents";
 import { StructuredData } from "@web/components/structured-data";
-import { SITE_URL } from "@web/config";
+import { SITE_TITLE, SITE_URL } from "@web/config";
 import { SOCIAL_HANDLE } from "@web/config/socials";
 import { getPostViewCount } from "@web/lib/data/posts";
 import { generateBreadcrumbSchema } from "@web/lib/metadata";
@@ -59,16 +59,16 @@ export const generateMetadata = async ({
     title: post.title,
     description: post.excerpt || "",
     keywords: post.tags ?? [],
-    authors: [{ name: "SG Cars Trends AI", url: SITE_URL }],
-    creator: "SG Cars Trends",
-    publisher: "SG Cars Trends",
+    authors: [{ name: `${SITE_TITLE} AI`, url: SITE_URL }],
+    creator: SITE_TITLE,
+    publisher: SITE_TITLE,
     openGraph: {
       title: post.title,
       description: post.excerpt || "",
       type: "article",
       publishedTime: publishedDate.toISOString(),
       modifiedTime: modifiedDate.toISOString(),
-      authors: ["SG Cars Trends"],
+      authors: [SITE_TITLE],
       tags: post.tags ?? [],
       url: `${SITE_URL}${canonical}`,
     },
@@ -161,12 +161,12 @@ export default async function BlogPostPage({ params }: PageProps) {
     inLanguage: "en-SG",
     author: {
       "@type": "Organization",
-      name: "SG Cars Trends",
+      name: SITE_TITLE,
       url: SITE_URL,
     },
     publisher: {
       "@type": "Organization",
-      name: "SG Cars Trends",
+      name: SITE_TITLE,
       url: SITE_URL,
     },
     image: {
@@ -178,7 +178,7 @@ export default async function BlogPostPage({ params }: PageProps) {
       post.dataType === "cars" ? "Market Analysis" : "COE Bidding",
     isPartOf: {
       "@type": "Blog",
-      name: "SG Cars Trends Blog",
+      name: `${SITE_TITLE} Blog`,
       url: `${SITE_URL}/blog`,
     },
   };

--- a/apps/web/src/app/(main)/(site)/learn/components/faq-data.ts
+++ b/apps/web/src/app/(main)/(site)/learn/components/faq-data.ts
@@ -1,6 +1,8 @@
 // Data extracted from faq-section.tsx because "use client" modules
 // don't expose non-component exports to Server Components.
 
+import { SITE_TITLE } from "@web/config";
+
 export interface FAQItem {
   question: string;
   answer: string;
@@ -51,7 +53,7 @@ export const FAQ_SECTIONS: FAQSectionData[] = [
           "Car registration data is updated monthly following the Land Transport Authority's (LTA) official data releases. The data typically becomes available 2-3 weeks after the end of each month and includes comprehensive breakdowns by manufacturer, fuel type, and vehicle category.",
       },
       {
-        question: "What data sources does SG Cars Trends use?",
+        question: `What data sources does ${SITE_TITLE} use?`,
         answer:
           "All vehicle registration and COE data is sourced directly from Singapore's Land Transport Authority (LTA), ensuring accuracy and official government backing. We process and format this data to provide insights and analytics for easier understanding of market trends.",
       },
@@ -98,7 +100,7 @@ export const FAQ_SECTIONS: FAQSectionData[] = [
     ],
   },
   {
-    title: "Using SG Cars Trends",
+    title: `Using ${SITE_TITLE}`,
     items: [
       {
         question: "How can I access historical data?",

--- a/apps/web/src/app/(main)/(site)/learn/components/faq-section.tsx
+++ b/apps/web/src/app/(main)/(site)/learn/components/faq-section.tsx
@@ -3,6 +3,7 @@
 import { Card, CardBody } from "@heroui/card";
 import { Accordion, AccordionItem } from "@heroui/react";
 import Typography from "@web/components/typography";
+import { SITE_TITLE } from "@web/config";
 import {
   fadeInUpVariants,
   staggerContainerVariants,
@@ -75,7 +76,7 @@ export const FAQ_SECTIONS: FAQSectionData[] = [
           "Car registration data is updated monthly following the Land Transport Authority's (LTA) official data releases. The data typically becomes available 2-3 weeks after the end of each month and includes comprehensive breakdowns by manufacturer, fuel type, and vehicle category.",
       },
       {
-        question: "What data sources does SG Cars Trends use?",
+        question: `What data sources does ${SITE_TITLE} use?`,
         answer:
           "All vehicle registration and COE data is sourced directly from Singapore's Land Transport Authority (LTA), ensuring accuracy and official government backing. We process and format this data to provide insights and analytics for easier understanding of market trends.",
       },
@@ -126,7 +127,7 @@ export const FAQ_SECTIONS: FAQSectionData[] = [
     ],
   },
   {
-    title: "Using SG Cars Trends",
+    title: `Using ${SITE_TITLE}`,
     icon: BarChart3,
     iconColor: "text-primary",
     items: [

--- a/apps/web/src/app/(main)/(site)/legal/privacy-policy/page.tsx
+++ b/apps/web/src/app/(main)/(site)/legal/privacy-policy/page.tsx
@@ -1,9 +1,9 @@
+import { SITE_TITLE } from "@web/config";
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
   title: "Privacy Policy",
-  description:
-    "How SG Cars Trends collects, uses, and protects your data. Learn about our analytics, third-party services, and your privacy rights.",
+  description: `How ${SITE_TITLE} collects, uses, and protects your data. Learn about our analytics, third-party services, and your privacy rights.`,
   alternates: {
     canonical: "/legal/privacy-policy",
   },
@@ -21,7 +21,7 @@ export default function PrivacyPage() {
         <h2>Privacy? We&apos;ve Got You Covered</h2>
         <p>
           We care about your privacy. This policy explains how we collect and
-          use your information when you visit SGCarsTrends. We&apos;ll keep it
+          use your information when you visit {SITE_TITLE}. We&apos;ll keep it
           simple and straightforward.
         </p>
       </section>

--- a/apps/web/src/app/(main)/(site)/legal/terms-of-service/page.tsx
+++ b/apps/web/src/app/(main)/(site)/legal/terms-of-service/page.tsx
@@ -1,9 +1,9 @@
+import { SITE_TITLE } from "@web/config";
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
   title: "Terms of Service",
-  description:
-    "Terms and conditions for using SG Cars Trends. Understand data usage rights, liability limits, and acceptable use of our Singapore car market platform.",
+  description: `Terms and conditions for using ${SITE_TITLE}. Understand data usage rights, liability limits, and acceptable use of our Singapore car market platform.`,
   alternates: {
     canonical: "/legal/terms-of-service",
   },
@@ -20,7 +20,7 @@ export default function TermsPage() {
       <section>
         <h2>Using Our Website</h2>
         <p>
-          By using SGCarsTrends, you agree to these terms. Pretty
+          By using {SITE_TITLE}, you agree to these terms. Pretty
           straightforward!
         </p>
       </section>

--- a/apps/web/src/app/admin/components/app-sidebar.tsx
+++ b/apps/web/src/app/admin/components/app-sidebar.tsx
@@ -145,7 +145,7 @@ export const AppSidebar = () => {
             <LayoutDashboard className="size-4 text-primary-foreground" />
           </div>
           <div className="grid flex-1 text-left text-sm leading-tight">
-            <span className="truncate font-semibold">SG Cars Admin</span>
+            <span className="truncate font-semibold">MotorMetrics Admin</span>
             <span className="truncate text-muted-foreground text-xs">
               {session?.user?.email || "Dashboard"}
             </span>

--- a/apps/web/src/app/api/og/coe/route.tsx
+++ b/apps/web/src/app/api/og/coe/route.tsx
@@ -49,8 +49,8 @@ export const GET = async (request: NextRequest) => {
           tw="ml-2 text-xl"
           style={{ textShadow: `0 2px 4px rgba(0,0,0,0.3)` }}
         >
-          <span tw="text-black">SGCars</span>
-          <span tw="text-blue-600">Trends</span>
+          <span tw="text-black">Motor</span>
+          <span tw="text-blue-600">Metrics</span>
         </span>
       </div>
       <div tw="flex w-full p-32">

--- a/apps/web/src/app/api/og/route.tsx
+++ b/apps/web/src/app/api/og/route.tsx
@@ -54,8 +54,8 @@ export const GET = async (request: NextRequest) => {
           tw="ml-2 text-xl"
           style={{ textShadow: `0 2px 4px rgba(0,0,0,0.3)` }}
         >
-          <span tw="text-black">SGCars</span>
-          <span tw="text-blue-600">Trends</span>
+          <span tw="text-black">Motor</span>
+          <span tw="text-blue-600">Metrics</span>
         </span>
       </div>
       <div tw="flex w-full p-32">

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -3,7 +3,7 @@ import { Analytics } from "@vercel/analytics/next";
 import { SpeedInsights } from "@vercel/speed-insights/next";
 import { Providers } from "@web/app/providers";
 import LoadingIndicator from "@web/components/loading-indicator";
-import { SITE_TITLE, SITE_URL } from "@web/config";
+import { SITE_DESCRIPTION, SITE_TITLE, SITE_URL } from "@web/config";
 import { SOCIAL_HANDLE } from "@web/config/socials";
 import type { Metadata } from "next";
 import { Geist } from "next/font/google";
@@ -17,7 +17,7 @@ const geistSans = Geist({
 });
 
 const title = SITE_TITLE;
-const description: string = `Statistics for car trends in Singapore. Data provided by Land Transport Authority (LTA)`;
+const description = SITE_DESCRIPTION;
 const url = new URL(SITE_URL);
 
 export const metadata: Metadata = {
@@ -27,9 +27,9 @@ export const metadata: Metadata = {
     default: title,
   },
   description,
-  authors: [{ name: "SG Cars Trends", url: SITE_URL }],
-  creator: "SG Cars Trends",
-  publisher: "SG Cars Trends",
+  authors: [{ name: SITE_TITLE, url: SITE_URL }],
+  creator: SITE_TITLE,
+  publisher: SITE_TITLE,
   category: "Automotive Statistics",
   robots: {
     index: true,
@@ -50,7 +50,7 @@ export const metadata: Metadata = {
         url: `${SITE_URL}/opengraph-image.png`,
         width: 1200,
         height: 630,
-        alt: "SG Cars Trends - Singapore Car Registration Statistics",
+        alt: `${SITE_TITLE} - Singapore Car Registration Statistics`,
       },
     ],
     url,

--- a/apps/web/src/components/__snapshots__/footer.test.tsx.snap
+++ b/apps/web/src/components/__snapshots__/footer.test.tsx.snap
@@ -193,7 +193,9 @@ exports[`Footer > should render asynchronous footer content with version informa
           >
             © 
             2026
-             SGCarsTrends. All rights reserved. • v
+             
+            MotorMetrics
+            . All rights reserved. • v
             0.0.0-test
           </p>
           <p

--- a/apps/web/src/components/__snapshots__/structured-data.test.tsx.snap
+++ b/apps/web/src/components/__snapshots__/structured-data.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`StructuredData > should inject JSON-LD script 1`] = `
     id="structured-data"
     type="application/ld+json"
   >
-    {"@context":"https://schema.org","@type":"Organization","name":"SG Cars Trends"}
+    {"@context":"https://schema.org","@type":"Organization","name":"MotorMetrics"}
   </script>
 </div>
 `;

--- a/apps/web/src/components/footer.tsx
+++ b/apps/web/src/components/footer.tsx
@@ -3,6 +3,7 @@ import { Divider } from "@heroui/divider";
 import { BrandLogo } from "@web/components/brand-logo";
 import Typography from "@web/components/typography";
 import { UnreleasedFeature } from "@web/components/unreleased-feature";
+import { SITE_TITLE } from "@web/config";
 import {
   NAV_ITEMS,
   navLinks,
@@ -81,7 +82,7 @@ export function Footer() {
         <div className="flex flex-col items-center justify-between gap-4 md:flex-row md:gap-0">
           <div className="text-center text-default-600 md:text-left">
             <Typography.TextSm>
-              © {CURRENT_YEAR} SGCarsTrends. All rights reserved. • v{version}
+              © {CURRENT_YEAR} {SITE_TITLE}. All rights reserved. • v{version}
             </Typography.TextSm>
             <Typography.TextSm>
               Data provided by{" "}

--- a/apps/web/src/components/structured-data.test.tsx
+++ b/apps/web/src/components/structured-data.test.tsx
@@ -1,5 +1,6 @@
 import { render } from "@testing-library/react";
 import { StructuredData } from "@web/components/structured-data";
+import { SITE_TITLE } from "@web/config";
 import type { Organization, WithContext } from "schema-dts";
 import { vi } from "vitest";
 
@@ -13,7 +14,7 @@ describe("StructuredData", () => {
     const data: WithContext<Organization> = {
       "@context": "https://schema.org",
       "@type": "Organization",
-      name: "SG Cars Trends",
+      name: SITE_TITLE,
     };
 
     const { container } = render(<StructuredData data={data} />);
@@ -23,6 +24,6 @@ describe("StructuredData", () => {
     ) as HTMLScriptElement;
 
     expect(script).toBeTruthy();
-    expect(script.textContent).toContain("SG Cars Trends");
+    expect(script.textContent).toContain(SITE_TITLE);
   });
 });

--- a/apps/web/src/config/index.ts
+++ b/apps/web/src/config/index.ts
@@ -4,18 +4,32 @@ import { VEHICLE_TYPE_MAP } from "@web/constants";
 import type { Announcement, LinkItem, VehicleType } from "@web/types";
 import { Battery, Droplet, Fuel, Zap } from "lucide-react";
 
+// =============================================================================
+// Brand Configuration
+// =============================================================================
+export const SITE_TITLE = "MotorMetrics";
+export const SITE_DESCRIPTION =
+  "Statistics for car trends in Singapore. Data provided by Land Transport Authority (LTA)";
+
+// =============================================================================
+// Domain & URLs (Phase 3 - update when new domain is live)
+// =============================================================================
 export const DOMAIN_NAME = "sgcarstrends.com";
-const API_VERSION = "v1";
 
 export const SITE_URL =
   process.env.NEXT_PUBLIC_SITE_URL ??
   (process.env.NEXT_PUBLIC_VERCEL_URL
     ? `https://${process.env.NEXT_PUBLIC_VERCEL_URL}`
     : `https://${DOMAIN_NAME}`);
-export const SITE_TITLE = "SG Cars Trends";
+
 export const LOGO_URL = `${SITE_URL}/icon.png`;
 
+// =============================================================================
+// API Configuration
+// =============================================================================
+const API_VERSION = "v1";
 const DEFAULT_API_URL = `https://api.${DOMAIN_NAME}`;
+
 export const API_BASE_URL =
   // TODO: Remove this check once Hono is working on Vercel
   process.env.NEXT_PUBLIC_API_URL ??
@@ -23,8 +37,18 @@ export const API_BASE_URL =
     projectName: "api",
     defaultHost: process.env.NEXT_PUBLIC_API_URL ?? DEFAULT_API_URL,
   });
+
 export const API_URL = `${API_BASE_URL}/${API_VERSION}`;
 
+// =============================================================================
+// Feature Flags
+// =============================================================================
+export const FEATURE_FLAG_UNRELEASED =
+  process.env.NEXT_PUBLIC_FEATURE_FLAG_UNRELEASED === "true";
+
+// =============================================================================
+// Data Constants (Fuel Types, Vehicle Types, etc.)
+// =============================================================================
 export enum FUEL_TYPE {
   DIESEL = "Diesel",
   DIESEL_ELECTRIC = "Diesel-Electric",
@@ -37,30 +61,6 @@ export enum FUEL_TYPE {
 }
 
 export const HYBRID_REGEX = /^(Diesel|Petrol)-(Electric)(\s\(Plug-In\))?$/;
-
-export const announcements: Announcement[] = [
-  // {
-  //   content: `🌟 Welcome to ${SITE_TITLE} - We are currently revamping the site!`,
-  //   paths: undefined, // Global announcement (fallback)
-  // },
-  // {
-  //   content: "🚗 Latest car registration data now available!",
-  //   paths: ["/cars"],
-  // },
-  // {
-  //   content: "📊 New COE bidding results are in!",
-  //   paths: ["/coe"],
-  // },
-];
-
-export const MEDAL_MAPPING: Record<number, string> = {
-  1: "🥇",
-  2: "🥈",
-  3: "🥉",
-};
-
-export const FEATURE_FLAG_UNRELEASED =
-  process.env.NEXT_PUBLIC_FEATURE_FLAG_UNRELEASED === "true";
 
 export const FUEL_TYPE_LINKS: LinkItem[] = [
   {
@@ -135,6 +135,33 @@ export const SITE_LINKS: LinkItem[] = [
   ...COE_LINKS,
 ];
 
+// =============================================================================
+// UI Constants
+// =============================================================================
+export const MEDAL_MAPPING: Record<number, string> = {
+  1: "🥇",
+  2: "🥈",
+  3: "🥉",
+};
+
+export const announcements: Announcement[] = [
+  // {
+  //   content: `🌟 Welcome to ${SITE_TITLE} - We are currently revamping the site!`,
+  //   paths: undefined, // Global announcement (fallback)
+  // },
+  // {
+  //   content: "🚗 Latest car registration data now available!",
+  //   paths: ["/cars"],
+  // },
+  // {
+  //   content: "📊 New COE bidding results are in!",
+  //   paths: ["/coe"],
+  // },
+];
+
+// =============================================================================
+// Cache Keys
+// =============================================================================
 export const LAST_UPDATED_CARS_KEY = "last_updated:cars";
 export const LAST_UPDATED_CAR_COSTS_KEY = "last_updated:car-costs";
 export const LAST_UPDATED_COE_KEY = "last_updated:coe";

--- a/apps/web/src/lib/metadata/structured-data.ts
+++ b/apps/web/src/lib/metadata/structured-data.ts
@@ -34,12 +34,12 @@ export function createWebPageStructuredData(
 const datasetBase = {
   creator: {
     "@type": "Organization" as const,
-    name: "SG Cars Trends",
+    name: SITE_TITLE,
     url: SITE_URL,
   },
   publisher: {
     "@type": "Organization" as const,
-    name: "SG Cars Trends",
+    name: SITE_TITLE,
     url: SITE_URL,
   },
   provider: {

--- a/apps/web/src/lib/og/config.ts
+++ b/apps/web/src/lib/og/config.ts
@@ -1,3 +1,5 @@
+import { DOMAIN_NAME, SITE_TITLE } from "@web/config";
+
 /**
  * OG image configuration
  */
@@ -10,10 +12,10 @@ export const OG_CONFIG = {
   fontFamily: "Geist",
 
   /** Site name for branding */
-  siteName: "SG Cars Trends",
+  siteName: SITE_TITLE,
 
   /** Site URL for branding */
-  siteUrl: "sgcarstrends.com",
+  siteUrl: DOMAIN_NAME,
 
   /** Border radius in pixels */
   borderRadius: 10,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -149,19 +149,19 @@ importers:
     dependencies:
       fumadocs-core:
         specifier: 16.7.7
-        version: 16.7.7(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.2(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react-router@7.13.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(zod@4.3.6)
+        version: 16.7.7(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.3(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react-router@7.13.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(zod@4.3.6)
       fumadocs-mdx:
         specifier: 14.2.11
-        version: 14.2.11(@types/mdast@4.0.4)(@types/mdx@2.0.13)(@types/react@19.2.10)(fumadocs-core@16.7.7(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.2(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react-router@7.13.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(zod@4.3.6))(next@16.2.2(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(vite@7.3.0(@types/node@25.2.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))
+        version: 14.2.11(@types/mdast@4.0.4)(@types/mdx@2.0.13)(@types/react@19.2.10)(fumadocs-core@16.7.7(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.3(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react-router@7.13.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(zod@4.3.6))(next@16.2.3(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(vite@7.3.0(@types/node@25.2.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))
       fumadocs-ui:
         specifier: 16.7.7
-        version: 16.7.7(@types/mdx@2.0.13)(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(fumadocs-core@16.7.7(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.2(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react-router@7.13.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(zod@4.3.6))(next@16.2.2(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(shiki@4.0.2)(tailwindcss@4.1.18)
+        version: 16.7.7(@types/mdx@2.0.13)(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(fumadocs-core@16.7.7(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.3(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react-router@7.13.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(zod@4.3.6))(next@16.2.3(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(shiki@4.0.2)(tailwindcss@4.1.18)
       lucide-react:
         specifier: 0.563.0
         version: 0.563.0(react@19.2.4)
       next:
-        specifier: 16.2.2
-        version: 16.2.2(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        specifier: 16.2.3
+        version: 16.2.3(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react:
         specifier: 19.2.4
         version: 19.2.4
@@ -3102,8 +3102,8 @@ packages:
   '@next/env@16.2.0':
     resolution: {integrity: sha512-OZIbODWWAi0epQRCRjNe1VO45LOFBzgiyqmTLzIqWq6u1wrxKnAyz1HH6tgY/Mc81YzIjRPoYsPAEr4QV4l9TA==}
 
-  '@next/env@16.2.2':
-    resolution: {integrity: sha512-LqSGz5+xGk9EL/iBDr2yo/CgNQV6cFsNhRR2xhSXYh7B/hb4nePCxlmDvGEKG30NMHDFf0raqSyOZiQrO7BkHQ==}
+  '@next/env@16.2.3':
+    resolution: {integrity: sha512-ZWXyj4uNu4GCWQw9cjRxWlbD+33mcDszIo9iQxFnBX3Wmgq9ulaSJcl6VhuWx5pCWqqD+9W6Wfz7N0lM5lYPMA==}
 
   '@next/swc-darwin-arm64@16.2.0':
     resolution: {integrity: sha512-/JZsqKzKt01IFoiLLAzlNqys7qk2F3JkcUhj50zuRhKDQkZNOz9E5N6wAQWprXdsvjRP4lTFj+/+36NSv5AwhQ==}
@@ -3111,8 +3111,8 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  '@next/swc-darwin-arm64@16.2.2':
-    resolution: {integrity: sha512-B92G3ulrwmkDSEJEp9+XzGLex5wC1knrmCSIylyVeiAtCIfvEJYiN3v5kXPlYt5R4RFlsfO/v++aKV63Acrugg==}
+  '@next/swc-darwin-arm64@16.2.3':
+    resolution: {integrity: sha512-u37KDKTKQ+OQLvY+z7SNXixwo4Q2/IAJFDzU1fYe66IbCE51aDSAzkNDkWmLN0yjTUh4BKBd+hb69jYn6qqqSg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
@@ -3123,8 +3123,8 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@next/swc-darwin-x64@16.2.2':
-    resolution: {integrity: sha512-7ZwSgNKJNQiwW0CKhNm9B1WS2L1Olc4B2XY0hPYCAL3epFnugMhuw5TMWzMilQ3QCZcCHoYm9NGWTHbr5REFxw==}
+  '@next/swc-darwin-x64@16.2.3':
+    resolution: {integrity: sha512-gHjL/qy6Q6CG3176FWbAKyKh9IfntKZTB3RY/YOJdDFpHGsUDXVH38U4mMNpHVGXmeYW4wj22dMp1lTfmu/bTQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
@@ -3136,8 +3136,8 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@next/swc-linux-arm64-gnu@16.2.2':
-    resolution: {integrity: sha512-c3m8kBHMziMgo2fICOP/cd/5YlrxDU5YYjAJeQLyFsCqVF8xjOTH/QYG4a2u48CvvZZSj1eHQfBCbyh7kBr30Q==}
+  '@next/swc-linux-arm64-gnu@16.2.3':
+    resolution: {integrity: sha512-U6vtblPtU/P14Y/b/n9ZY0GOxbbIhTFuaFR7F4/uMBidCi2nSdaOFhA0Go81L61Zd6527+yvuX44T4ksnf8T+Q==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
@@ -3150,8 +3150,8 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@next/swc-linux-arm64-musl@16.2.2':
-    resolution: {integrity: sha512-VKLuscm0P/mIfzt+SDdn2+8TNNJ7f0qfEkA+az7OqQbjzKdBxAHs0UvuiVoCtbwX+dqMEL9U54b5wQ/aN3dHeg==}
+  '@next/swc-linux-arm64-musl@16.2.3':
+    resolution: {integrity: sha512-/YV0LgjHUmfhQpn9bVoGc4x4nan64pkhWR5wyEV8yCOfwwrH630KpvRg86olQHTwHIn1z59uh6JwKvHq1h4QEw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
@@ -3164,8 +3164,8 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@next/swc-linux-x64-gnu@16.2.2':
-    resolution: {integrity: sha512-kU3OPHJq6sBUjOk7wc5zJ7/lipn8yGldMoAv4z67j6ov6Xo/JvzA7L7LCsyzzsXmgLEhk3Qkpwqaq/1+XpNR3g==}
+  '@next/swc-linux-x64-gnu@16.2.3':
+    resolution: {integrity: sha512-/HiWEcp+WMZ7VajuiMEFGZ6cg0+aYZPqCJD3YJEfpVWQsKYSjXQG06vJP6F1rdA03COD9Fef4aODs3YxKx+RDQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
@@ -3178,8 +3178,8 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@next/swc-linux-x64-musl@16.2.2':
-    resolution: {integrity: sha512-CKXRILyErMtUftp+coGcZ38ZwE/Aqq45VMCcRLr2I4OXKrgxIBDXHnBgeX/UMil0S09i2JXaDL3Q+TN8D/cKmg==}
+  '@next/swc-linux-x64-musl@16.2.3':
+    resolution: {integrity: sha512-Kt44hGJfZSefebhk/7nIdivoDr3Ugp5+oNz9VvF3GUtfxutucUIHfIO0ZYO8QlOPDQloUVQn4NVC/9JvHRk9hw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
@@ -3191,8 +3191,8 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  '@next/swc-win32-arm64-msvc@16.2.2':
-    resolution: {integrity: sha512-sS/jSk5VUoShUqINJFvNjVT7JfR5ORYj/+/ZpOYbbIohv/lQfduWnGAycq2wlknbOql2xOR0DoV0s6Xfcy49+g==}
+  '@next/swc-win32-arm64-msvc@16.2.3':
+    resolution: {integrity: sha512-O2NZ9ie3Tq6xj5Z5CSwBT3+aWAMW2PIZ4egUi9MaWLkwaehgtB7YZjPm+UpcNpKOme0IQuqDcor7BsW6QBiQBw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
@@ -3203,8 +3203,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@next/swc-win32-x64-msvc@16.2.2':
-    resolution: {integrity: sha512-aHaKceJgdySReT7qeck5oShucxWRiiEuwCGK8HHALe6yZga8uyFpLkPgaRw3kkF04U7ROogL/suYCNt/+CuXGA==}
+  '@next/swc-win32-x64-msvc@16.2.3':
+    resolution: {integrity: sha512-Ibm29/GgB/ab5n7XKqlStkm54qqZE8v2FnijUPBgrd67FWrac45o/RsNlaOWjme/B5UqeWt/8KM4aWBwA1D2Kw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -8566,8 +8566,8 @@ packages:
       sass:
         optional: true
 
-  next@16.2.2:
-    resolution: {integrity: sha512-i6AJdyVa4oQjyvX/6GeER8dpY/xlIV+4NMv/svykcLtURJSy/WzDnnUk/TM4d0uewFHK7xSQz4TbIwPgjky+3A==}
+  next@16.2.3:
+    resolution: {integrity: sha512-9V3zV4oZFza3PVev5/poB9g0dEafVcgNyQ8eTRop8GvxZjV2G15FC5ARuG1eFD42QgeYkzJBJzHghNP8Ad9xtA==}
     engines: {node: '>=20.9.0'}
     hasBin: true
     peerDependencies:
@@ -14190,54 +14190,54 @@ snapshots:
 
   '@next/env@16.2.0': {}
 
-  '@next/env@16.2.2': {}
+  '@next/env@16.2.3': {}
 
   '@next/swc-darwin-arm64@16.2.0':
     optional: true
 
-  '@next/swc-darwin-arm64@16.2.2':
+  '@next/swc-darwin-arm64@16.2.3':
     optional: true
 
   '@next/swc-darwin-x64@16.2.0':
     optional: true
 
-  '@next/swc-darwin-x64@16.2.2':
+  '@next/swc-darwin-x64@16.2.3':
     optional: true
 
   '@next/swc-linux-arm64-gnu@16.2.0':
     optional: true
 
-  '@next/swc-linux-arm64-gnu@16.2.2':
+  '@next/swc-linux-arm64-gnu@16.2.3':
     optional: true
 
   '@next/swc-linux-arm64-musl@16.2.0':
     optional: true
 
-  '@next/swc-linux-arm64-musl@16.2.2':
+  '@next/swc-linux-arm64-musl@16.2.3':
     optional: true
 
   '@next/swc-linux-x64-gnu@16.2.0':
     optional: true
 
-  '@next/swc-linux-x64-gnu@16.2.2':
+  '@next/swc-linux-x64-gnu@16.2.3':
     optional: true
 
   '@next/swc-linux-x64-musl@16.2.0':
     optional: true
 
-  '@next/swc-linux-x64-musl@16.2.2':
+  '@next/swc-linux-x64-musl@16.2.3':
     optional: true
 
   '@next/swc-win32-arm64-msvc@16.2.0':
     optional: true
 
-  '@next/swc-win32-arm64-msvc@16.2.2':
+  '@next/swc-win32-arm64-msvc@16.2.3':
     optional: true
 
   '@next/swc-win32-x64-msvc@16.2.0':
     optional: true
 
-  '@next/swc-win32-x64-msvc@16.2.2':
+  '@next/swc-win32-x64-msvc@16.2.3':
     optional: true
 
   '@noble/ciphers@2.1.1': {}
@@ -18877,7 +18877,7 @@ snapshots:
       mkdirp: 0.5.6
       rimraf: 2.7.1
 
-  fumadocs-core@16.7.7(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.2(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react-router@7.13.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(zod@4.3.6):
+  fumadocs-core@16.7.7(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.3(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react-router@7.13.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(zod@4.3.6):
     dependencies:
       '@formatjs/intl-localematcher': 0.8.2
       '@orama/orama': 3.1.18
@@ -18909,7 +18909,7 @@ snapshots:
       '@types/mdast': 4.0.4
       '@types/react': 19.2.10
       lucide-react: 0.563.0(react@19.2.4)
-      next: 16.2.2(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      next: 16.2.3(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
       react-router: 7.13.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -18917,14 +18917,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  fumadocs-mdx@14.2.11(@types/mdast@4.0.4)(@types/mdx@2.0.13)(@types/react@19.2.10)(fumadocs-core@16.7.7(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.2(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react-router@7.13.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(zod@4.3.6))(next@16.2.2(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(vite@7.3.0(@types/node@25.2.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)):
+  fumadocs-mdx@14.2.11(@types/mdast@4.0.4)(@types/mdx@2.0.13)(@types/react@19.2.10)(fumadocs-core@16.7.7(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.3(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react-router@7.13.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(zod@4.3.6))(next@16.2.3(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(vite@7.3.0(@types/node@25.2.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)):
     dependencies:
       '@mdx-js/mdx': 3.1.1
       '@standard-schema/spec': 1.1.0
       chokidar: 5.0.0
       esbuild: 0.27.4
       estree-util-value-to-estree: 3.5.0
-      fumadocs-core: 16.7.7(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.2(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react-router@7.13.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(zod@4.3.6)
+      fumadocs-core: 16.7.7(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.3(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react-router@7.13.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(zod@4.3.6)
       js-yaml: 4.1.1
       mdast-util-mdx: 3.0.0
       mdast-util-to-markdown: 2.1.2
@@ -18941,13 +18941,13 @@ snapshots:
       '@types/mdast': 4.0.4
       '@types/mdx': 2.0.13
       '@types/react': 19.2.10
-      next: 16.2.2(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      next: 16.2.3(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react: 19.2.4
       vite: 7.3.0(@types/node@25.2.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
     transitivePeerDependencies:
       - supports-color
 
-  fumadocs-ui@16.7.7(@types/mdx@2.0.13)(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(fumadocs-core@16.7.7(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.2(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react-router@7.13.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(zod@4.3.6))(next@16.2.2(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(shiki@4.0.2)(tailwindcss@4.1.18):
+  fumadocs-ui@16.7.7(@types/mdx@2.0.13)(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(fumadocs-core@16.7.7(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.3(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react-router@7.13.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(zod@4.3.6))(next@16.2.3(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(shiki@4.0.2)(tailwindcss@4.1.18):
     dependencies:
       '@fumadocs/tailwind': 0.0.3(tailwindcss@4.1.18)
       '@radix-ui/react-accordion': 1.2.12(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -18961,7 +18961,7 @@ snapshots:
       '@radix-ui/react-slot': 1.2.4(@types/react@19.2.10)(react@19.2.4)
       '@radix-ui/react-tabs': 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       class-variance-authority: 0.7.1
-      fumadocs-core: 16.7.7(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.2(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react-router@7.13.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(zod@4.3.6)
+      fumadocs-core: 16.7.7(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.3(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react-router@7.13.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(zod@4.3.6)
       lucide-react: 1.7.0(react@19.2.4)
       motion: 12.38.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       next-themes: 0.4.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -18976,7 +18976,7 @@ snapshots:
     optionalDependencies:
       '@types/mdx': 2.0.13
       '@types/react': 19.2.10
-      next: 16.2.2(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      next: 16.2.3(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       shiki: 4.0.2
     transitivePeerDependencies:
       - '@emotion/is-prop-valid'
@@ -20504,9 +20504,9 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
-  next@16.2.2(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+  next@16.2.3(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
-      '@next/env': 16.2.2
+      '@next/env': 16.2.3
       '@swc/helpers': 0.5.15
       baseline-browser-mapping: 2.10.8
       caniuse-lite: 1.0.30001761
@@ -20515,14 +20515,14 @@ snapshots:
       react-dom: 19.2.4(react@19.2.4)
       styled-jsx: 5.1.6(@babel/core@7.28.5)(react@19.2.4)
     optionalDependencies:
-      '@next/swc-darwin-arm64': 16.2.2
-      '@next/swc-darwin-x64': 16.2.2
-      '@next/swc-linux-arm64-gnu': 16.2.2
-      '@next/swc-linux-arm64-musl': 16.2.2
-      '@next/swc-linux-x64-gnu': 16.2.2
-      '@next/swc-linux-x64-musl': 16.2.2
-      '@next/swc-win32-arm64-msvc': 16.2.2
-      '@next/swc-win32-x64-msvc': 16.2.2
+      '@next/swc-darwin-arm64': 16.2.3
+      '@next/swc-darwin-x64': 16.2.3
+      '@next/swc-linux-arm64-gnu': 16.2.3
+      '@next/swc-linux-arm64-musl': 16.2.3
+      '@next/swc-linux-x64-gnu': 16.2.3
+      '@next/swc-linux-x64-musl': 16.2.3
+      '@next/swc-win32-arm64-msvc': 16.2.3
+      '@next/swc-win32-x64-msvc': 16.2.3
       '@opentelemetry/api': 1.9.0
       '@playwright/test': 1.57.0
       babel-plugin-react-compiler: 1.0.0


### PR DESCRIPTION
- Centralize branding in `SITE_TITLE` and `SITE_DESCRIPTION` constants
- Reorganize config file with clear sections (Brand, Domain, API, Data, UI, Cache)
- Update all user-visible text from "SG Cars Trends" to use `SITE_TITLE`
- Replace hardcoded strings in metadata, OG images, structured data, legal pages, FAQs
- Update tests and snapshots to use centralized constants

Relates #749 (Phase 2: Frontend pages only — domains and package names in separate phases)