### PR TITLE
fix(web): proxy PostHog array assets

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -95,6 +95,10 @@ const nextConfig: NextConfig = {
         destination: "https://eu-assets.i.posthog.com/static/:path*",
       },
       {
+        source: "/ingest/array/:path*",
+        destination: "https://eu-assets.i.posthog.com/array/:path*",
+      },
+      {
         source: "/ingest/:path*",
         destination: "https://eu.i.posthog.com/:path*",
       },


### PR DESCRIPTION
## Summary
- Add the missing PostHog EU `/ingest/array/:path*` reverse-proxy rewrite.
- Keep `/ingest/static` and `/ingest` ordering aligned with PostHog Next.js/Vercel proxy docs.

## Validation
- `pnpm --filter @motormetrics/web typecheck`
- `pnpm --filter @motormetrics/web build`
- `pnpm --filter @motormetrics/web lint` reported existing unrelated Biome warnings outside this hotfix file.