### PR TITLE
fix(web): back-merge PostHog proxy hotfix

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -95,6 +95,10 @@ const nextConfig: NextConfig = {
         destination: "https://eu-assets.i.posthog.com/static/:path*",
       },
       {
+        source: "/ingest/array/:path*",
+        destination: "https://eu-assets.i.posthog.com/array/:path*",
+      },
+      {
         source: "/ingest/:path*",
         destination: "https://eu.i.posthog.com/:path*",
       },


### PR DESCRIPTION
## Summary
- Back-merge the production PostHog reverse-proxy hotfix from `release`.
- Add the missing EU `/ingest/array/:path*` asset rewrite required by PostHog proxy docs.

## Validation
- `pnpm --filter @motormetrics/web typecheck`
- Same change already passed CI and merged to `release` in #770.