### PR TITLE
Remove Umami analytics

### DIFF
--- a/apps/web/CLAUDE.md
+++ b/apps/web/CLAUDE.md
@@ -1142,7 +1142,7 @@ Deployed via Vercel with automatic deployments:
 - **TypeScript**: Strict mode enabled
 - **Turbopack**: Enabled for faster builds and development
 - **Feature Flags**: Controlled via `NEXT_PUBLIC_FEATURE_FLAG_UNRELEASED`
-- **Analytics**: Integrated with Umami analytics
+- **Analytics**: Vercel Analytics (pageviews/Web Vitals) and PostHog (product events)
 
 ## UI Component Strategy
 

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -8,7 +8,6 @@ import { SOCIAL_HANDLE } from "@web/config/socials";
 import { BotIdClient } from "botid/client";
 import type { Metadata } from "next";
 import { Geist } from "next/font/google";
-import Script from "next/script";
 import { NuqsAdapter } from "nuqs/adapters/next/app";
 import { type ReactNode, Suspense } from "react";
 import "./globals.css";
@@ -102,12 +101,6 @@ const RootLayout = async ({ children }: { children: ReactNode }) => {
         <Analytics />
         <SpeedInsights />
       </body>
-      <Script
-        defer
-        src="https://analytics.motormetrics.app/script.js"
-        data-website-id="b98dda44-ccc9-4a73-87d4-dcbe561aedb8"
-        data-domains="motormetrics.app"
-      />
     </html>
   );
 };


### PR DESCRIPTION
- Remove the self-hosted Umami pageview `<Script>` from the web app root layout; it was redundant with Vercel Analytics (pageviews/Web Vitals) and PostHog (product events), and had no custom event tracking
- Drop the now-unused `next/script` import and update the analytics note in `apps/web/CLAUDE.md`
- No npm dependency or env vars involved; decommissioning the `analytics.motormetrics.app` instance (infra/DNS) is a separate ops task