### PR TITLE
Add instant navigation Playwright specs

### DIFF
--- a/apps/web/CLAUDE.md
+++ b/apps/web/CLAUDE.md
@@ -35,7 +35,7 @@ pnpm format             # Format code with Biome
 - **State Management**: Zustand with persistence
 - **Styling**: Tailwind CSS v4 with HeroUI components
 - **Animations**: Framer Motion with shared variants (`@web/config/animations`)
-- **Testing**: Vitest for unit tests, Playwright for E2E
+- **Testing**: Vitest for unit tests, Playwright for E2E (including `@next/playwright` instant navigations)
 - **Deployment**: Vercel (Singapore region)
 
 ### Key Directories

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -87,6 +87,7 @@
     "@babel/core": "7.29.6",
     "@babel/preset-env": "7.29.5",
     "@babel/preset-typescript": "7.28.5",
+    "@next/playwright": "16.3.0",
     "@playwright/test": "1.60.0",
     "@react-email/render": "2.0.8",
     "@rolldown/plugin-babel": "0.2.3",

--- a/apps/web/tests/instant-navigation.spec.ts
+++ b/apps/web/tests/instant-navigation.spec.ts
@@ -1,0 +1,84 @@
+import { instant } from "@next/playwright";
+import { expect, test } from "@playwright/test";
+
+const KNOWN_BLOG_SLUG =
+  "electric-vehicles-dominate-singapore-car-market-march-2026";
+
+test.describe("Instant Navigations", () => {
+  test.describe.configure({ mode: "serial" });
+  test.setTimeout(90_000);
+
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript(() => {
+      window.localStorage.setItem(
+        "motormetrics:notification-prompt-dismissed",
+        "true",
+      );
+    });
+  });
+
+  test("should show car registrations shell instantly from home", async ({
+    page,
+  }) => {
+    // Start at home, then open cars hub which exposes the registrations Link.
+    await page.goto("/", { waitUntil: "domcontentloaded" });
+    await expect(
+      page.getByRole("heading", { level: 1, name: "Overview" }),
+    ).toBeVisible({ timeout: 60_000 });
+
+    await page.goto("/cars", { waitUntil: "domcontentloaded" });
+    await expect(
+      page.locator('a[href="/cars/registrations"]').first(),
+    ).toBeVisible({ timeout: 60_000 });
+
+    await instant(page, async () => {
+      await page.click('a[href="/cars/registrations"]');
+      await expect(
+        page.getByRole("heading", { level: 1, name: "Car Registrations" }),
+      ).toBeVisible();
+    });
+  });
+
+  test("should show COE results shell instantly from home", async ({
+    page,
+  }) => {
+    await page.goto("/", { waitUntil: "domcontentloaded" });
+    await expect(
+      page.getByRole("heading", { level: 1, name: "Overview" }),
+    ).toBeVisible({ timeout: 60_000 });
+
+    await page.goto("/coe", { waitUntil: "domcontentloaded" });
+    await expect(page.locator('a[href="/coe/results"]').first()).toBeVisible({
+      timeout: 60_000,
+    });
+
+    await instant(page, async () => {
+      await page.click('a[href="/coe/results"]');
+      await expect(
+        page.getByRole("heading", { level: 1, name: "COE Results" }),
+      ).toBeVisible();
+    });
+  });
+
+  test("should show blog post shell instantly from blog list", async ({
+    page,
+  }) => {
+    await page.goto("/blog", { waitUntil: "domcontentloaded" });
+    await expect(page.getByRole("heading", { level: 1 })).toBeVisible({
+      timeout: 60_000,
+    });
+
+    const postLink = page.locator(`a[href="/blog/${KNOWN_BLOG_SLUG}"]`).first();
+    const fallbackLink = page
+      .locator('a[href^="/blog/"]')
+      .filter({ hasNotText: "Back" })
+      .first();
+    const link = (await postLink.count()) > 0 ? postLink : fallbackLink;
+    await expect(link).toBeVisible({ timeout: 60_000 });
+
+    await instant(page, async () => {
+      await link.click();
+      await expect(page.getByRole("heading", { level: 1 })).toBeVisible();
+    });
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -404,6 +404,9 @@ importers:
       '@babel/preset-typescript':
         specifier: 7.28.5
         version: 7.28.5(@babel/core@7.29.6(supports-color@8.1.1))
+      '@next/playwright':
+        specifier: 16.3.0
+        version: 16.3.0(@playwright/test@1.60.0)
       '@playwright/test':
         specifier: 1.60.0
         version: 1.60.0
@@ -463,7 +466,7 @@ importers:
         version: 1.0.0
       jsdom:
         specifier: 26.1.0
-        version: 26.1.0
+        version: 26.1.0(supports-color@8.1.1)
       postcss:
         specifier: 8.5.15
         version: 8.5.15
@@ -2534,6 +2537,14 @@ packages:
 
   '@next/env@16.3.0':
     resolution: {integrity: sha512-o9r1S0BNiNreHP9Vs+Qnqd9kviDkJh8xIACY7UFZSmiGbbQRzPBBosvHzAU4TULHOIuOj/18RSsyz2qrREmIFw==}
+
+  '@next/playwright@16.3.0':
+    resolution: {integrity: sha512-lYFQDfksErmwifriLvnuhywiTqKtC7faxbLQSO2cmsrfVJsXA0L3cV1IqsXu7lhA8bFOOAxyvNBTtYyzKdKDew==}
+    peerDependencies:
+      '@playwright/test': '>=1.0.0'
+    peerDependenciesMeta:
+      '@playwright/test':
+        optional: true
 
   '@next/swc-darwin-arm64@16.3.0':
     resolution: {integrity: sha512-55hpqq18bEVAlxedlTt3tFqZmKg2nUXT1kn1G/BGEy0R13h3LwtwHPVzzjG6P4LLeOHE32PFDQUVaJEWvBEZBw==}
@@ -11561,6 +11572,10 @@ snapshots:
 
   '@next/env@16.3.0': {}
 
+  '@next/playwright@16.3.0(@playwright/test@1.60.0)':
+    optionalDependencies:
+      '@playwright/test': 1.60.0
+
   '@next/swc-darwin-arm64@16.3.0':
     optional: true
 
@@ -15760,7 +15775,7 @@ snapshots:
       statuses: 2.0.2
       toidentifier: 1.0.1
 
-  http-proxy-agent@7.0.2:
+  http-proxy-agent@7.0.2(supports-color@8.1.1):
     dependencies:
       agent-base: 7.1.4
       debug: 4.4.3(supports-color@8.1.1)
@@ -15779,7 +15794,7 @@ snapshots:
       quick-lru: 5.1.1
       resolve-alpn: 1.2.1
 
-  https-proxy-agent@7.0.6:
+  https-proxy-agent@7.0.6(supports-color@8.1.1):
     dependencies:
       agent-base: 7.1.4
       debug: 4.4.3(supports-color@8.1.1)
@@ -16013,14 +16028,14 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
-  jsdom@26.1.0:
+  jsdom@26.1.0(supports-color@8.1.1):
     dependencies:
       cssstyle: 4.6.0
       data-urls: 5.0.0
       decimal.js: 10.6.0
       html-encoding-sniffer: 4.0.0
-      http-proxy-agent: 7.0.2
-      https-proxy-agent: 7.0.6
+      http-proxy-agent: 7.0.2(supports-color@8.1.1)
+      https-proxy-agent: 7.0.6(supports-color@8.1.1)
       is-potential-custom-element-name: 1.0.1
       nwsapi: 2.2.23
       parse5: 7.3.0
@@ -18843,7 +18858,7 @@ snapshots:
       '@types/node': 24.13.2
       '@vitest/coverage-v8': 4.1.6(vitest@4.1.6)
       '@vitest/ui': 4.1.6(vitest@4.1.6)
-      jsdom: 26.1.0
+      jsdom: 26.1.0(supports-color@8.1.1)
     transitivePeerDependencies:
       - msw
 


### PR DESCRIPTION
- Add `@next/playwright` for Next.js Instant Navigations helpers
- Cover registrations, COE results, and blog post shell navigations with `instant()`
- Note the helper in web CLAUDE/AGENTS testing stack