### PR TITLE
Document the push-then-generate schema workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,6 +92,11 @@ Core cross-cutting variables:
 
 Vercel, Singapore region. Push to main deploys production; pull requests get preview URLs.
 
+`vercel-build` runs `db:migrate` before `next build`, so **every deploy applies pending
+migrations** — including previews, which target the shared `staging` Neon branch. An
+unmerged PR's migration therefore lands on staging permanently. The `development`
+branch is managed by `db:push` instead and receives no migrations.
+
 ## Domain Convention
 
 - **API**: `<service>.<environment>.motormetrics.app` (e.g., `api.motormetrics.app`)

--- a/README.md
+++ b/README.md
@@ -225,7 +225,6 @@ pnpm db:migrate            # Run database migrations
 pnpm db:migrate:check      # Check migration status
 pnpm db:generate           # Generate new migrations
 pnpm db:push               # Push schema changes
-pnpm db:drop               # Drop database
 ```
 
 ### Deployment

--- a/docs/architecture/database.md
+++ b/docs/architecture/database.md
@@ -320,16 +320,19 @@ While the schema doesn't use foreign key constraints, there are logical relation
 **Migration Workflow**:
 ```bash
 # 1. Modify schema files in packages/database/src/schema/
-# 2. Generate migration
-pnpm generate
+# 2. Apply to the development branch and iterate there
+pnpm db:push
 
-# 3. Review generated SQL in migrations/ directory
-# 4. Apply migration
-pnpm migrate
+# 3. Once the shape has settled, generate the migration
+pnpm db:generate
 
-# 5. Verify schema consistency
-pnpm migrate:check
+# 4. Review generated SQL in migrations/, then commit it —
+#    staging and production apply it on deploy via vercel-build.
 ```
+
+Do not run `pnpm db:migrate` against development: `push` has already applied the
+changes without recording a ledger row, so the migration replays and fails. See
+[packages/database/CLAUDE.md](../../packages/database/CLAUDE.md) for the full rules.
 
 ### Schema Evolution
 

--- a/packages/database/CLAUDE.md
+++ b/packages/database/CLAUDE.md
@@ -2,11 +2,17 @@
 
 ## Schema Change Workflow
 
-Modify schema files in `src/schema/` → `pnpm generate` → review the generated SQL in
-`migrations/` → `pnpm migrate` → `pnpm migrate:check` to validate consistency.
-Types update automatically via Drizzle inference; never hand-edit generated migrations
-or `migrations/meta/_journal.json`. Always generate and test a migration before
-production — never rely on `pnpm push` outside local development.
+Modify schema files in `src/schema/`, then `pnpm push` to apply them to the
+**development** Neon branch and iterate there. Once the shape has settled, `pnpm
+generate` → review the generated SQL in `migrations/` → `pnpm migrate` →
+`pnpm migrate:check` to validate consistency. Types update automatically via Drizzle
+inference; never hand-edit generated migrations or `migrations/meta/_journal.json`.
+
+`push` is for **development only**. It mutates the schema without recording a row in
+`drizzle.__drizzle_migrations`, so the development ledger drifts from the repo by
+design and should never be "repaired" to match. Staging and production get schema
+changes solely through generated migrations applied by `migrate` — always generate and
+test a migration before production.
 
 ## Naming Conventions
 

--- a/packages/database/CLAUDE.md
+++ b/packages/database/CLAUDE.md
@@ -4,15 +4,17 @@
 
 Modify schema files in `src/schema/`, then `pnpm push` to apply them to the
 **development** Neon branch and iterate there. Once the shape has settled, `pnpm
-generate` → review the generated SQL in `migrations/` → `pnpm migrate` →
-`pnpm migrate:check` to validate consistency. Types update automatically via Drizzle
-inference; never hand-edit generated migrations or `migrations/meta/_journal.json`.
+generate` and review the generated SQL in `migrations/`. Commit it — staging and
+production apply it on deploy, since `vercel-build` runs `db:migrate`. Types update
+automatically via Drizzle inference; never hand-edit generated migrations.
 
-`push` is for **development only**. It mutates the schema without recording a row in
-`drizzle.__drizzle_migrations`, so the development ledger drifts from the repo by
-design and should never be "repaired" to match. Staging and production get schema
-changes solely through generated migrations applied by `migrate` — always generate and
-test a migration before production.
+**Do not run `pnpm migrate` against development.** `push` has already applied those
+changes, but without recording a row in `drizzle.__drizzle_migrations`, so `migrate`
+sees the new migration as pending and replays SQL against a schema that already has
+it — `ADD COLUMN` then fails as already-exists. The development ledger drifts from the
+repo by design and should never be "repaired" to match. To rehearse a migration, point
+`DATABASE_URL` at a fresh Neon branch of production and run `pnpm migrate` plus
+`pnpm migrate:check` there.
 
 ## Naming Conventions
 


### PR DESCRIPTION
- Record that schema changes are applied to the development Neon branch with `pnpm push` first, and only reach staging and production as generated migrations applied by `migrate`
- Spell out that `push` writes no `drizzle.__drizzle_migrations` row, so development's ledger drifts from the repo by design and should not be "repaired"

The previous wording described a generate-first flow, which reads as though development's ledger drift is damage. It isn't — but that misreading cost real time while diagnosing the Drizzle v1 migration failure in #894.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/motormetrics/codesmith/motormetrics/pr/898"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788932192&installation_model_id=21947&pr_number=898&repository=motormetrics%2Fmotormetrics&return_to=https%3A%2F%2Fgithub.com%2Fmotormetrics%2Fmotormetrics%2Fpull%2F898&signature=3417ce9691eb963d68dceb619e89eb1e65354382562d1361123d128a73fbacb1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->