### PR TITLE
Add Boneyard capture and skeleton renderer

### DIFF
--- a/apps/web/.gitignore
+++ b/apps/web/.gitignore
@@ -37,3 +37,7 @@ next-env.d.ts
 .env.local
 # heroui-agents-md
 .heroui-docs/
+
+# Boneyard client registry — bones JSON is committed; we render it as RSC
+/src/bones/registry.js
+/src/bones/registry.ts

--- a/apps/web/boneyard.config.json
+++ b/apps/web/boneyard.config.json
@@ -1,0 +1,6 @@
+{
+  "out": "./src/bones",
+  "breakpoints": [375, 768, 1280],
+  "wait": 3000,
+  "skeletons": {}
+}

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -1,7 +1,13 @@
+import path from "node:path";
 import { withBotId } from "botid/next/config";
 import type { NextConfig } from "next";
 import createNextIntlPlugin from "next-intl/plugin";
 import { withWorkflow } from "workflow/next";
+
+const BONEYARD_CAPTURE_CLIENT =
+  "@web/components/shared/bones-capture-runtime.client";
+const BONEYARD_CAPTURE_STUB =
+  "./src/components/shared/bones-capture-runtime.stub.tsx";
 
 const ONE_DAY = 60 * 60 * 24;
 
@@ -60,6 +66,43 @@ const nextConfig: NextConfig = {
     turbopackFileSystemCacheForBuild: true,
     turbopackRustReactCompiler: true,
     typedEnv: true,
+  },
+  // Capture runtime is a next-dev Playwright hook. Production must not resolve
+  // `boneyard-js` (devDependency) or emit its client chunk.
+  ...(process.env.NODE_ENV === "production"
+    ? {
+        turbopack: {
+          resolveAlias: {
+            [BONEYARD_CAPTURE_CLIENT]: BONEYARD_CAPTURE_STUB,
+            "boneyard-js": BONEYARD_CAPTURE_STUB,
+            "boneyard-js/react": BONEYARD_CAPTURE_STUB,
+          },
+        },
+      }
+    : {}),
+  webpack: (config, { dev, dir }) => {
+    if (!dev) {
+      const stub = path.resolve(
+        dir,
+        "src/components/shared/bones-capture-runtime.stub.tsx",
+      );
+      config.resolve ??= {};
+      const alias = config.resolve.alias;
+      config.resolve.alias = {
+        ...(alias && !Array.isArray(alias) ? alias : {}),
+        [BONEYARD_CAPTURE_CLIENT]: stub,
+        [path.join(dir, "src/components/shared/bones-capture-runtime.client")]:
+          stub,
+        [path.join(
+          dir,
+          "src/components/shared/bones-capture-runtime.client.tsx",
+        )]: stub,
+        "boneyard-js": stub,
+        "boneyard-js/react": stub,
+      };
+    }
+
+    return config;
   },
   skipTrailingSlashRedirect: true,
   async redirects() {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -17,6 +17,7 @@
     "test:integration": "vitest run --config vitest.integration.config.ts",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
+    "bones": "boneyard-js build --no-scan http://localhost:3000/",
     "typecheck": "tsc --noEmit",
     "auth:generate": "pnpm dlx auth@rc generate --config ./src/app/admin/lib/auth.ts --output ../../packages/database/src/schema/auth.ts --yes",
     "vercel-build": "turbo run @motormetrics/database#migrate && next build"
@@ -109,6 +110,7 @@
     "@vitest/coverage-v8": "catalog:",
     "@workflow/vitest": "4.0.17",
     "babel-plugin-react-compiler": "1.0.0",
+    "boneyard-js": "1.9.0",
     "jsdom": "26.1.0",
     "postcss": "8.5.23",
     "tailwindcss": "catalog:",

--- a/apps/web/src/app/(main)/layout.tsx
+++ b/apps/web/src/app/(main)/layout.tsx
@@ -2,7 +2,7 @@ import { Announcement } from "@web/components/announcement";
 import { AppNavbar } from "@web/components/app-navbar";
 import { Banner } from "@web/components/banner";
 import { NotificationPrompt } from "@web/components/notification-prompt";
-import { BonesCaptureRuntime } from "@web/components/shared/bones-capture-runtime.client";
+import { BonesCaptureRuntime } from "@web/components/shared/bones-capture-runtime";
 import type { ReactNode } from "react";
 
 export default function MainLayout({

--- a/apps/web/src/app/(main)/layout.tsx
+++ b/apps/web/src/app/(main)/layout.tsx
@@ -2,6 +2,7 @@ import { Announcement } from "@web/components/announcement";
 import { AppNavbar } from "@web/components/app-navbar";
 import { Banner } from "@web/components/banner";
 import { NotificationPrompt } from "@web/components/notification-prompt";
+import { BonesCaptureRuntime } from "@web/components/shared/bones-capture-runtime.client";
 import type { ReactNode } from "react";
 
 export default function MainLayout({
@@ -9,6 +10,7 @@ export default function MainLayout({
 }: Readonly<{ children: ReactNode }>) {
   return (
     <>
+      <BonesCaptureRuntime />
       <NotificationPrompt />
       <Announcement />
       <AppNavbar />

--- a/apps/web/src/components/shared/bones-capture-runtime.client.tsx
+++ b/apps/web/src/components/shared/bones-capture-runtime.client.tsx
@@ -2,7 +2,7 @@
 
 import "boneyard-js/react";
 
-/** Registers Boneyard's Playwright snapshot hook. Renders nothing. */
+/** Registers Boneyard's Playwright snapshot hook during local CLI capture. */
 export function BonesCaptureRuntime() {
   return null;
 }

--- a/apps/web/src/components/shared/bones-capture-runtime.client.tsx
+++ b/apps/web/src/components/shared/bones-capture-runtime.client.tsx
@@ -1,0 +1,8 @@
+"use client";
+
+import "boneyard-js/react";
+
+/** Registers Boneyard's Playwright snapshot hook. Renders nothing. */
+export function BonesCaptureRuntime() {
+  return null;
+}

--- a/apps/web/src/components/shared/bones-capture-runtime.stub.tsx
+++ b/apps/web/src/components/shared/bones-capture-runtime.stub.tsx
@@ -1,0 +1,4 @@
+/** Production stand-in for the Boneyard capture client — no `boneyard-js`. */
+export function BonesCaptureRuntime() {
+  return null;
+}

--- a/apps/web/src/components/shared/bones-capture-runtime.test.tsx
+++ b/apps/web/src/components/shared/bones-capture-runtime.test.tsx
@@ -1,0 +1,10 @@
+import { render } from "@testing-library/react";
+import { BonesCaptureRuntime } from "./bones-capture-runtime";
+
+describe("BonesCaptureRuntime", () => {
+  it("should render nothing outside next dev", () => {
+    const { container } = render(<BonesCaptureRuntime />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/apps/web/src/components/shared/bones-capture-runtime.tsx
+++ b/apps/web/src/components/shared/bones-capture-runtime.tsx
@@ -1,0 +1,13 @@
+import { BonesCaptureRuntime as BonesCaptureDevRuntime } from "@web/components/shared/bones-capture-runtime.client";
+
+/**
+ * Registers Boneyard's Playwright snapshot hook during `next dev`.
+ * Production builds compile this to a no-op and never load `boneyard-js`.
+ */
+export function BonesCaptureRuntime() {
+  if (process.env.NODE_ENV !== "development") {
+    return null;
+  }
+
+  return <BonesCaptureDevRuntime />;
+}

--- a/apps/web/src/components/shared/bones-skeleton.test.tsx
+++ b/apps/web/src/components/shared/bones-skeleton.test.tsx
@@ -1,0 +1,104 @@
+import { render } from "@testing-library/react";
+import { BonesSkeleton } from "./bones-skeleton";
+
+const singleBreakpoint = {
+  name: "summary-card",
+  width: 400,
+  height: 120,
+  bones: [
+    [0, 0, 100, 120, 16, true],
+    [8, 16, 24, 40, 8],
+    [80, 16, 10, 40, "50%"],
+  ],
+};
+
+const responsiveBones = {
+  breakpoints: {
+    375: {
+      name: "summary-card",
+      width: 375,
+      height: 200,
+      bones: [[0, 0, 100, 48, 8]],
+    },
+    768: {
+      name: "summary-card",
+      width: 768,
+      height: 160,
+      bones: [[0, 0, 50, 48, 8]],
+    },
+    1280: {
+      name: "summary-card",
+      width: 1280,
+      height: 120,
+      bones: [[0, 0, 33, 48, 8]],
+    },
+  },
+};
+
+describe("BonesSkeleton", () => {
+  it("should render leaf and container bones from a single layout", () => {
+    const { container } = render(<BonesSkeleton bones={singleBreakpoint} />);
+    const bones = container.querySelectorAll("[aria-hidden] > div");
+
+    expect(bones).toHaveLength(3);
+    expect(bones[0]).toHaveClass("bg-surface");
+    expect(bones[1]).toHaveClass("animate-pulse", "bg-default");
+  });
+
+  it("should accept object-form bones as well as compact tuples", () => {
+    const { container } = render(
+      <BonesSkeleton
+        bones={{
+          width: 200,
+          height: 40,
+          bones: [{ x: 0, y: 0, w: 50, h: 40, r: 8 }],
+        }}
+      />,
+    );
+    const bone = container.querySelector("[aria-hidden] > div");
+
+    expect(bone).toHaveStyle({
+      left: "0%",
+      width: "50%",
+      height: "40px",
+      borderRadius: "8px",
+    });
+  });
+
+  it("should size circular bones with matching width and height", () => {
+    const { container } = render(<BonesSkeleton bones={singleBreakpoint} />);
+    const circle = container.querySelectorAll("[aria-hidden] > div")[2];
+
+    expect(circle).toHaveStyle({
+      width: "40px",
+      height: "40px",
+      borderRadius: "50%",
+    });
+  });
+
+  it("should emit a layout per breakpoint switched by CSS media queries", () => {
+    const { container } = render(<BonesSkeleton bones={responsiveBones} />);
+    const layers = container.querySelectorAll(
+      ".summary-card-375, .summary-card-768, .summary-card-1280",
+    );
+    const css = container.querySelector("style")?.textContent ?? "";
+
+    expect(layers).toHaveLength(3);
+    expect(css).toContain(".summary-card-375{display:block}");
+    expect(css).toContain(
+      "@media (min-width:768px){.summary-card-375{display:none}}",
+    );
+    expect(css).toContain(
+      "@media (min-width:768px){.summary-card-768{display:block}}",
+    );
+    expect(css).toContain(
+      "@media (min-width:1280px){.summary-card-1280{display:block}}",
+    );
+  });
+
+  it("should render nothing when a responsive map has no breakpoints", () => {
+    const { container } = render(<BonesSkeleton bones={{ breakpoints: {} }} />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/apps/web/src/components/shared/bones-skeleton.tsx
+++ b/apps/web/src/components/shared/bones-skeleton.tsx
@@ -1,0 +1,172 @@
+import { cn } from "@heroui/react";
+import type { ReactNode } from "react";
+
+/** Skip icon paths and canvases during CLI capture. */
+export const BONES_SNAPSHOT_CONFIG = JSON.stringify({
+  excludeSelectors: ["svg", "canvas"],
+});
+
+interface BonesCaptureProps {
+  name: string;
+  children: ReactNode;
+  className?: string;
+}
+
+/** Marks real UI for `npx boneyard-js build` without using the client Skeleton. */
+export function BonesCapture({ name, children, className }: BonesCaptureProps) {
+  return (
+    <div
+      className={className}
+      data-boneyard={name}
+      data-boneyard-config={BONES_SNAPSHOT_CONFIG}
+    >
+      {children}
+    </div>
+  );
+}
+
+type BoneObject = {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+  r: number | string;
+  c?: boolean;
+};
+
+type CompactBone = Array<number | string | boolean>;
+
+export type BonesResult = {
+  name?: string;
+  viewportWidth?: number;
+  width: number;
+  height: number;
+  bones: Array<CompactBone | BoneObject>;
+};
+
+export type ResponsiveBones = {
+  breakpoints: Record<string | number, BonesResult>;
+  _hash?: string;
+};
+
+export type BonesInput = BonesResult | ResponsiveBones;
+
+interface BonesSkeletonProps {
+  bones: BonesInput;
+  className?: string;
+}
+
+function isResponsive(bones: BonesInput): bones is ResponsiveBones {
+  return "breakpoints" in bones && bones.breakpoints != null;
+}
+
+function normalizeBone(raw: CompactBone | BoneObject): BoneObject {
+  if (Array.isArray(raw)) {
+    return {
+      x: Number(raw[0]),
+      y: Number(raw[1]),
+      w: Number(raw[2]),
+      h: Number(raw[3]),
+      r: raw[4] as number | string,
+      c: Boolean(raw[5]),
+    };
+  }
+
+  return raw;
+}
+
+function skeletonName(bones: BonesInput): string {
+  if (isResponsive(bones)) {
+    const first = Object.values(bones.breakpoints)[0];
+    return first?.name ?? "bones";
+  }
+
+  return bones.name ?? "bones";
+}
+
+function breakpointCss(uid: string, widths: number[]): string {
+  return widths
+    .map((width, index) => {
+      const nextWidth = widths[index + 1];
+      const selector = `.${uid}-${width}`;
+
+      if (nextWidth == null && index === 0) {
+        return `${selector}{display:block}`;
+      }
+
+      if (index === 0) {
+        return `${selector}{display:block}@media (min-width:${nextWidth}px){${selector}{display:none}}`;
+      }
+
+      if (nextWidth == null) {
+        return `${selector}{display:none}@media (min-width:${width}px){${selector}{display:block}}`;
+      }
+
+      return `${selector}{display:none}@media (min-width:${width}px){${selector}{display:block}}@media (min-width:${nextWidth}px){${selector}{display:none}}`;
+    })
+    .join("");
+}
+
+function BreakpointBones({ result }: { result: BonesResult }) {
+  return (
+    <div
+      aria-hidden
+      className="relative w-full overflow-hidden"
+      style={{ height: result.height }}
+    >
+      {result.bones.map((raw, index) => {
+        const bone = normalizeBone(raw);
+        const capturedPxW = (bone.w / 100) * (result.width || 0);
+        const isCircle = bone.r === "50%" && Math.abs(capturedPxW - bone.h) < 4;
+
+        return (
+          <div
+            // biome-ignore lint/suspicious/noArrayIndexKey: bones are a static captured list
+            key={index}
+            className={cn(
+              "absolute",
+              bone.c ? "bg-surface" : "animate-pulse bg-default",
+            )}
+            style={{
+              left: `${bone.x}%`,
+              top: bone.y,
+              width: isCircle ? bone.h : `${bone.w}%`,
+              height: bone.h,
+              borderRadius: typeof bone.r === "string" ? bone.r : `${bone.r}px`,
+            }}
+          />
+        );
+      })}
+    </div>
+  );
+}
+
+/**
+ * Server Component skeleton from Boneyard capture JSON.
+ * Renders all breakpoints into the static shell and switches with CSS.
+ */
+export function BonesSkeleton({ bones, className }: BonesSkeletonProps) {
+  const entries = isResponsive(bones)
+    ? Object.entries(bones.breakpoints)
+        .map(([width, result]) => [Number(width), result] as const)
+        .sort((left, right) => left[0] - right[0])
+    : ([[0, bones]] as const);
+
+  if (entries.length === 0) {
+    return null;
+  }
+
+  const uid = skeletonName(bones).replaceAll(/[^a-zA-Z0-9_-]/g, "-");
+  const widths = entries.map(([width]) => width);
+
+  return (
+    <div className={className}>
+      <style href={`bones-${uid}`}>{breakpointCss(uid, widths)}</style>
+      {entries.map(([width, result]) => (
+        <div key={width} className={`${uid}-${width}`}>
+          <BreakpointBones result={result} />
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/components/shared/index.ts
+++ b/apps/web/src/components/shared/index.ts
@@ -1,3 +1,4 @@
+export { BonesCapture, BonesSkeleton } from "./bones-skeleton";
 export { NewChip } from "./chips";
 export { EmptyState } from "./empty-state";
 export { LastUpdated } from "./last-updated";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -215,7 +215,7 @@ importers:
     dependencies:
       '@modelcontextprotocol/sdk':
         specifier: 1.29.0
-        version: 1.29.0(supports-color@8.1.1)(zod@4.4.3)
+        version: 1.29.0(zod@4.4.3)
       '@vercel/related-projects':
         specifier: 'catalog:'
         version: 1.1.0
@@ -484,13 +484,16 @@ importers:
         version: 4.1.6(vitest@4.1.6)
       '@workflow/vitest':
         specifier: 4.0.17
-        version: 4.0.17(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.23)(vite@8.0.11(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.4))(vitest@4.1.6)
+        version: 4.0.17(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.23)(supports-color@8.1.1)(vite@8.0.11(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.4))(vitest@4.1.6)
       babel-plugin-react-compiler:
         specifier: 1.0.0
         version: 1.0.0
+      boneyard-js:
+        specifier: 1.9.0
+        version: 1.9.0(preact@10.29.1)(react@19.2.6)(vite@8.0.11(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.4))
       jsdom:
         specifier: 26.1.0
-        version: 26.1.0
+        version: 26.1.0(supports-color@8.1.1)
       postcss:
         specifier: 8.5.23
         version: 8.5.23
@@ -1433,6 +1436,9 @@ packages:
     resolution: {integrity: sha512-dI+9P7cfWxkTQ+oE+7Aa6onEn92PHgfWXZivjNheCRmTBDBf2fx6RyTi0cmgpYLnD1KLZK9ZYrMxaPZ4oiXhGA==}
     cpu: [x64]
     os: [win32]
+
+  '@chenglou/pretext@0.0.5':
+    resolution: {integrity: sha512-A8GZN10REdFGsyuiUgLV8jjPDDFMg5GmgxGWV0I3igxBOnzj+jgz2VMmVD7g+SFyoctfeqHFxbNatKSzVRWtRg==}
 
   '@clack/core@1.1.0':
     resolution: {integrity: sha512-SVcm4Dqm2ukn64/8Gub2wnlA5nS2iWJyCkdNHcvNHPIeBTGojpdJ+9cZKwLfmqy7irD4N5qLteSilJlE0WLAtA==}
@@ -4928,6 +4934,33 @@ packages:
   body-parser@2.2.2:
     resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
     engines: {node: '>=18'}
+
+  boneyard-js@1.9.0:
+    resolution: {integrity: sha512-FlIHm7YyQ6GMBPaNY6um5ESHNyZGONoSZ0IMhayuyemBsCUhhDl4nC/gMTOi/25ojtrlnRInTWKqFKb7hGK6Cg==}
+    hasBin: true
+    peerDependencies:
+      '@angular/core': '>=14'
+      preact: '>=10'
+      react: '>=18'
+      react-native: '>=0.71'
+      svelte: '>=5.29'
+      vite: '>=5'
+      vue: '>=3'
+    peerDependenciesMeta:
+      '@angular/core':
+        optional: true
+      preact:
+        optional: true
+      react:
+        optional: true
+      react-native:
+        optional: true
+      svelte:
+        optional: true
+      vite:
+        optional: true
+      vue:
+        optional: true
 
   botid@1.5.11:
     resolution: {integrity: sha512-KOO1A3+/vFVJk5aFoG3sNwiogKFPVR+x4aw4gQ1b2e0XoE+i5xp48/EZn+WqR07jRHeDGwHWQUOtV5WVm7xiww==}
@@ -10268,6 +10301,9 @@ snapshots:
   '@cbor-extract/cbor-extract-win32-x64@2.2.2':
     optional: true
 
+  '@chenglou/pretext@0.0.5':
+    optional: true
+
   '@clack/core@1.1.0':
     dependencies:
       sisteransi: 1.0.5
@@ -11013,7 +11049,7 @@ snapshots:
       '@types/react': 19.2.14
       react: 19.2.6
 
-  '@modelcontextprotocol/sdk@1.29.0(supports-color@8.1.1)(zod@4.4.3)':
+  '@modelcontextprotocol/sdk@1.29.0(zod@4.4.3)':
     dependencies:
       '@hono/node-server': 1.19.14(hono@4.12.18)
       ajv: 8.20.0
@@ -11023,8 +11059,8 @@ snapshots:
       cross-spawn: 7.0.6
       eventsource: 3.0.7
       eventsource-parser: 3.0.8
-      express: 5.2.1(supports-color@8.1.1)
-      express-rate-limit: 8.5.1(express@5.2.1(supports-color@8.1.1))
+      express: 5.2.1
+      express-rate-limit: 8.5.1(express@5.2.1)
       hono: 4.12.18
       jose: 6.2.3
       json-schema-typed: 8.0.2
@@ -12948,7 +12984,7 @@ snapshots:
   '@workflow/builders@4.1.6(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.23)':
     dependencies:
       '@swc/core': 1.15.3(@swc/helpers@0.5.23)
-      '@workflow/core': 4.8.1(@opentelemetry/api@1.9.1)
+      '@workflow/core': 4.8.1(@opentelemetry/api@1.9.1)(supports-color@8.1.1)
       '@workflow/errors': 4.2.1
       '@workflow/swc-plugin': 4.1.2(@swc/core@1.15.3(@swc/helpers@0.5.23))
       '@workflow/utils': 4.1.4
@@ -12971,7 +13007,7 @@ snapshots:
       '@swc/core': 1.15.3(@swc/helpers@0.5.23)
       '@vercel/cli-auth': 0.0.1
       '@workflow/builders': 4.1.6(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.23)
-      '@workflow/core': 4.8.1(@opentelemetry/api@1.9.1)
+      '@workflow/core': 4.8.1(@opentelemetry/api@1.9.1)(supports-color@8.1.1)
       '@workflow/errors': 4.2.1
       '@workflow/swc-plugin': 4.1.2(@swc/core@1.15.3(@swc/helpers@0.5.23))
       '@workflow/utils': 4.1.4
@@ -13001,7 +13037,7 @@ snapshots:
       - '@swc/helpers'
       - supports-color
 
-  '@workflow/core@4.8.1(@opentelemetry/api@1.9.1)':
+  '@workflow/core@4.8.1(@opentelemetry/api@1.9.1)(supports-color@8.1.1)':
     dependencies:
       '@aws-sdk/credential-provider-web-identity': 3.972.49
       '@jridgewell/trace-mapping': 0.3.31
@@ -13050,7 +13086,7 @@ snapshots:
     dependencies:
       '@swc/core': 1.15.3(@swc/helpers@0.5.23)
       '@workflow/builders': 4.1.6(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.23)
-      '@workflow/core': 4.8.1(@opentelemetry/api@1.9.1)
+      '@workflow/core': 4.8.1(@opentelemetry/api@1.9.1)(supports-color@8.1.1)
       '@workflow/swc-plugin': 4.1.2(@swc/core@1.15.3(@swc/helpers@0.5.23))
       semver: 7.7.4
       watchpack: 2.5.1
@@ -13065,7 +13101,7 @@ snapshots:
     dependencies:
       '@swc/core': 1.15.3(@swc/helpers@0.5.23)
       '@workflow/builders': 4.1.6(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.23)
-      '@workflow/core': 4.8.1(@opentelemetry/api@1.9.1)
+      '@workflow/core': 4.8.1(@opentelemetry/api@1.9.1)(supports-color@8.1.1)
       '@workflow/rollup': 4.0.16(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.23)
       '@workflow/swc-plugin': 4.1.2(@swc/core@1.15.3(@swc/helpers@0.5.23))
       '@workflow/vite': 4.0.16(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.23)
@@ -13137,10 +13173,10 @@ snapshots:
       - '@swc/helpers'
       - supports-color
 
-  '@workflow/vitest@4.0.17(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.23)(vite@8.0.11(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.4))(vitest@4.1.6)':
+  '@workflow/vitest@4.0.17(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.23)(supports-color@8.1.1)(vite@8.0.11(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.4))(vitest@4.1.6)':
     dependencies:
       '@workflow/builders': 4.1.6(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.23)
-      '@workflow/core': 4.8.1(@opentelemetry/api@1.9.1)
+      '@workflow/core': 4.8.1(@opentelemetry/api@1.9.1)(supports-color@8.1.1)
       '@workflow/rollup': 4.0.16(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.23)
       '@workflow/world': 4.3.1
       '@workflow/world-local': 4.2.4(@opentelemetry/api@1.9.1)
@@ -13154,7 +13190,7 @@ snapshots:
 
   '@workflow/web@4.1.17':
     dependencies:
-      express: 5.2.1(supports-color@8.1.1)
+      express: 5.2.1
     transitivePeerDependencies:
       - supports-color
 
@@ -13550,7 +13586,7 @@ snapshots:
 
   bluebird@3.4.7: {}
 
-  body-parser@2.2.2(supports-color@8.1.1):
+  body-parser@2.2.2:
     dependencies:
       bytes: 3.1.2
       content-type: 1.0.5
@@ -13563,6 +13599,15 @@ snapshots:
       type-is: 2.0.1
     transitivePeerDependencies:
       - supports-color
+
+  boneyard-js@1.9.0(preact@10.29.1)(react@19.2.6)(vite@8.0.11(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.4)):
+    dependencies:
+      playwright: 1.60.0
+    optionalDependencies:
+      '@chenglou/pretext': 0.0.5
+      preact: 10.29.1
+      react: 19.2.6
+      vite: 8.0.11(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.4)
 
   botid@1.5.11(next@16.3.0(@babel/core@7.29.6(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6):
     optionalDependencies:
@@ -14417,15 +14462,15 @@ snapshots:
 
   expect-type@1.3.0: {}
 
-  express-rate-limit@8.5.1(express@5.2.1(supports-color@8.1.1)):
+  express-rate-limit@8.5.1(express@5.2.1):
     dependencies:
-      express: 5.2.1(supports-color@8.1.1)
+      express: 5.2.1
       ip-address: 10.2.0
 
-  express@5.2.1(supports-color@8.1.1):
+  express@5.2.1:
     dependencies:
       accepts: 2.0.0
-      body-parser: 2.2.2(supports-color@8.1.1)
+      body-parser: 2.2.2
       content-disposition: 1.1.0
       content-type: 1.0.5
       cookie: 0.7.2
@@ -14435,7 +14480,7 @@ snapshots:
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
-      finalhandler: 2.1.1(supports-color@8.1.1)
+      finalhandler: 2.1.1
       fresh: 2.0.0
       http-errors: 2.0.1
       merge-descriptors: 2.0.0
@@ -14446,8 +14491,8 @@ snapshots:
       proxy-addr: 2.0.7
       qs: 6.15.1
       range-parser: 1.2.1
-      router: 2.2.0(supports-color@8.1.1)
-      send: 1.2.1(supports-color@8.1.1)
+      router: 2.2.0
+      send: 1.2.1
       serve-static: 2.2.1
       statuses: 2.0.2
       type-is: 2.0.1
@@ -14531,7 +14576,7 @@ snapshots:
     dependencies:
       to-regex-range: 5.0.1
 
-  finalhandler@2.1.1(supports-color@8.1.1):
+  finalhandler@2.1.1:
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
       encodeurl: 2.0.0
@@ -15003,7 +15048,7 @@ snapshots:
       statuses: 2.0.2
       toidentifier: 1.0.1
 
-  http-proxy-agent@7.0.2:
+  http-proxy-agent@7.0.2(supports-color@8.1.1):
     dependencies:
       agent-base: 7.1.4
       debug: 4.4.3(supports-color@8.1.1)
@@ -15022,7 +15067,7 @@ snapshots:
       quick-lru: 5.1.1
       resolve-alpn: 1.2.1
 
-  https-proxy-agent@7.0.6:
+  https-proxy-agent@7.0.6(supports-color@8.1.1):
     dependencies:
       agent-base: 7.1.4
       debug: 4.4.3(supports-color@8.1.1)
@@ -15254,14 +15299,14 @@ snapshots:
 
   jsbi@4.3.2: {}
 
-  jsdom@26.1.0:
+  jsdom@26.1.0(supports-color@8.1.1):
     dependencies:
       cssstyle: 4.6.0
       data-urls: 5.0.0
       decimal.js: 10.6.0
       html-encoding-sniffer: 4.0.0
-      http-proxy-agent: 7.0.2
-      https-proxy-agent: 7.0.6
+      http-proxy-agent: 7.0.2(supports-color@8.1.1)
+      https-proxy-agent: 7.0.6(supports-color@8.1.1)
       is-potential-custom-element-name: 1.0.1
       nwsapi: 2.2.23
       parse5: 7.3.0
@@ -17027,7 +17072,7 @@ snapshots:
 
   rou3@0.7.12: {}
 
-  router@2.2.0(supports-color@8.1.1):
+  router@2.2.0:
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
       depd: 2.0.0
@@ -17139,7 +17184,7 @@ snapshots:
 
   semver@7.8.5: {}
 
-  send@1.2.1(supports-color@8.1.1):
+  send@1.2.1:
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
       encodeurl: 2.0.0
@@ -17160,7 +17205,7 @@ snapshots:
       encodeurl: 2.0.0
       escape-html: 1.0.3
       parseurl: 1.3.3
-      send: 1.2.1(supports-color@8.1.1)
+      send: 1.2.1
     transitivePeerDependencies:
       - supports-color
 
@@ -17993,7 +18038,7 @@ snapshots:
       '@types/node': 24.13.2
       '@vitest/coverage-v8': 4.1.6(vitest@4.1.6)
       '@vitest/ui': 4.1.6(vitest@4.1.6)
-      jsdom: 26.1.0
+      jsdom: 26.1.0(supports-color@8.1.1)
     transitivePeerDependencies:
       - msw
 
@@ -18055,7 +18100,7 @@ snapshots:
     dependencies:
       '@workflow/astro': 4.0.16(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.23)
       '@workflow/cli': 4.3.5(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.23)
-      '@workflow/core': 4.8.1(@opentelemetry/api@1.9.1)
+      '@workflow/core': 4.8.1(@opentelemetry/api@1.9.1)(supports-color@8.1.1)
       '@workflow/errors': 4.2.1
       '@workflow/nest': 4.0.17(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.19(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.1)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.23))(chokidar@5.0.0))(@swc/core@1.15.3(@swc/helpers@0.5.23))(@swc/helpers@0.5.23)
       '@workflow/next': 4.1.5(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.23)(next@16.3.0(@babel/core@7.29.6(supports-color@8.1.1))(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(@types/node@24.13.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))


### PR DESCRIPTION
- Add BonesCapture, BonesSkeleton, and the boneyard-js CLI wiring
- Mount the capture runtime in the main layout so CLI snapshots can run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are mostly dev tooling and UI placeholders; production is guarded by stubs and NODE_ENV, though Next webpack/turbopack aliases add a small build-config surface area.
> 
> **Overview**
> Adds **Boneyard** (`boneyard-js`) so the web app can capture layout “bones” in dev and render them as server-component skeletons in production.
> 
> **Capture pipeline:** `boneyard.config.json`, a `bones` script (`boneyard-js build`), and **`BonesCapture`** wrappers (`data-boneyard`) mark UI for Playwright snapshots. **`BonesCaptureRuntime`** is mounted on the main layout and loads `boneyard-js/react` only in development; production builds alias the capture client and `boneyard-js` to a no-op stub via **webpack** and **turbopack** so the devDependency never ships.
> 
> **Rendering:** **`BonesSkeleton`** turns committed capture JSON into pulse placeholders (single or multi-breakpoint layouts switched with injected CSS). Shared exports and unit tests cover the skeleton and runtime behavior. Generated `src/bones/registry.*` is gitignored.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a710cef8384db6a139b9060b9259d3e81ce1f090. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->